### PR TITLE
Remove unnecessary clones flagged by clippy

### DIFF
--- a/src/hermite/mod.rs
+++ b/src/hermite/mod.rs
@@ -52,7 +52,7 @@ impl GaussHermite {
             .nodes
             .iter()
             .zip(self.weights.iter())
-            .map(|(x_val, w_val)| (integrand)(x_val.clone()) * w_val)
+            .map(|(&x_val, w_val)| integrand(x_val) * w_val)
             .sum();
         result
     }

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -89,11 +89,13 @@ impl GaussJacobi {
             .nodes
             .iter()
             .zip(self.weights.iter())
-            .map(|(x_val, w_val)| {
-                (integrand)((GaussJacobi::argument_transformation)(x_val.clone(), a, b)) * w_val
+            .map(|(&x_val, w_val)| {
+                integrand(
+                    GaussJacobi::argument_transformation(x_val, a, b)
+                ) * w_val
             })
             .sum();
-        (GaussJacobi::scale_factor)(a, b) * result
+        GaussJacobi::scale_factor(a, b) * result
     }
 }
 

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -70,7 +70,7 @@ impl GaussLaguerre {
             .nodes
             .iter()
             .zip(self.weights.iter())
-            .map(|(x_val, w_val)| (integrand)(x_val.clone()) * w_val)
+            .map(|(&x_val, w_val)| integrand(x_val) * w_val)
             .sum();
         result
     }

--- a/src/legendre/mod.rs
+++ b/src/legendre/mod.rs
@@ -61,15 +61,13 @@ impl GaussLegendre {
             .nodes
             .iter()
             .zip(self.weights.iter())
-            .map(|(x_val, w_val)| {
-                (integrand)((GaussLegendre::argument_transformation)(
-                    x_val.clone(),
-                    a,
-                    b,
-                )) * w_val
+            .map(|(&x_val, w_val)| {
+                integrand(
+                    GaussLegendre::argument_transformation(x_val, a, b,)
+                ) * w_val
             })
             .sum();
-        (GaussLegendre::scale_factor)(a, b) * result
+        GaussLegendre::scale_factor(a, b) * result
     }
 }
 


### PR DESCRIPTION
Ran clippy and found some extraneous clone calls. 
Pattern match the reference to simplify the function call. 