### PR TITLE
Try and fix docs.rs "crate is not a library" message for crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/domidre/gauss-quad"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
-crate-type = ["cdylib", "lib"]
+crate-type = ["lib", "cdylib"]
 
 [dependencies]
 nalgebra = "0.18"


### PR DESCRIPTION
I think the docs.rs "gauss-quad-0.1.3 is not a library" message for version [0.1.3](https://docs.rs/crate/gauss-quad/0.1.3) might be resolved by putting the `lib` crate-type first in `Cargo.toml`? 