### PR TITLE
Change order of lib in crate-type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/domidre/gauss-quad"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
-crate-type = ["cdylib", "lib"]
+crate-type = ["lib", "cdylib"]
 
 [dependencies]
 nalgebra = "0.18"


### PR DESCRIPTION
Putting lib first in crate-type as suggested in #8 to fix "not a library" bug in doc