### PR TITLE
Documentation tweaks: add docstrings to all submodules and quadrature structs, remove use of no longer needed language features from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ where QUADRATURE_RULE can currently be set to calculate either:
 | Simpson         | $$\int_a^b f(x) \mathrm{d}x$$                              |
 | GaussLegendre   | $$\int_a^b f(x) \mathrm{d}x$$                              |
 | GaussJacobi     | $$\int_a^b f(x)(1-x)^\alpha (1&plus;x)^\beta \mathrm{d}x$$ |
-| GaussLaguerre   | $$\int_{-\infty}^\infty f(x)x^\alpha e^{-x} \mathrm{d}x$$  |
+| GaussLaguerre   | $$\int_{0}^\infty f(x)x^\alpha e^{-x} \mathrm{d}x$$  |
 | GaussHermite    | $$\int_{-\infty}^\infty f(x) e^{-x^2} \mathrm{d}x$$        |
 
 For the quadrature rules that take an additional parameter, such as Gauss-Laguerre and Gauss-Jacobi, the parameters have to be added to the initialization, e.g.

--- a/src/gamma.rs
+++ b/src/gamma.rs
@@ -1,9 +1,7 @@
-/*!
-The gamma function provided in this module is copied directly from stats.rs:
-<https://docs.rs/statrs/latest/src/statrs/function/gamma.rs.html>
-
-The reason for this is the reduction of dependencies.
- */
+//! The gamma function provided in this module is copied directly from stats.rs:
+//! <https://docs.rs/statrs/latest/src/statrs/function/gamma.rs.html>
+//! 
+//! The reason for this is the reduction of dependencies.
 
 /// Constant value for `2 * sqrt(e / pi)`
 const TWO_SQRT_E_OVER_PI: f64 = 1.860_382_734_205_265_7;

--- a/src/gamma.rs
+++ b/src/gamma.rs
@@ -36,11 +36,11 @@ pub(crate) fn gamma(x: f64) -> f64 {
             .skip(1)
             .fold(GAMMA_DK[0], |s, t| s + t.1 / (t.0 as f64 - x));
 
-        std::f64::consts::PI
-            / ((std::f64::consts::PI * x).sin()
+        core::f64::consts::PI
+            / ((core::f64::consts::PI * x).sin()
                 * s
                 * TWO_SQRT_E_OVER_PI
-                * ((0.5 - x + GAMMA_R) / std::f64::consts::E).powf(0.5 - x))
+                * ((0.5 - x + GAMMA_R) / core::f64::consts::E).powf(0.5 - x))
     } else {
         let s = GAMMA_DK
             .iter()
@@ -48,14 +48,14 @@ pub(crate) fn gamma(x: f64) -> f64 {
             .skip(1)
             .fold(GAMMA_DK[0], |s, t| s + t.1 / (x + t.0 as f64 - 1.0));
 
-        s * TWO_SQRT_E_OVER_PI * ((x - 0.5 + GAMMA_R) / std::f64::consts::E).powf(x - 0.5)
+        s * TWO_SQRT_E_OVER_PI * ((x - 0.5 + GAMMA_R) / core::f64::consts::E).powf(x - 0.5)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use approx::assert_abs_diff_eq;
-    use std::f64::{self, consts};
+    use core::f64::{self, consts};
 
     #[test]
     fn test_gamma() {

--- a/src/gamma.rs
+++ b/src/gamma.rs
@@ -1,6 +1,6 @@
 //! The gamma function provided in this module is copied directly from stats.rs:
 //! <https://docs.rs/statrs/latest/src/statrs/function/gamma.rs.html>
-//! 
+//!
 //! The reason for this is the reduction of dependencies.
 
 /// Constant value for `2 * sqrt(e / pi)`

--- a/src/gamma.rs
+++ b/src/gamma.rs
@@ -1,6 +1,6 @@
 /*!
 The gamma function provided in this module is copied directly from stats.rs:
-https://docs.rs/statrs/latest/src/statrs/function/gamma.rs.html
+<https://docs.rs/statrs/latest/src/statrs/function/gamma.rs.html>
 
 The reason for this is the reduction of dependencies.
  */

--- a/src/gaussian_quadrature.rs
+++ b/src/gaussian_quadrature.rs
@@ -1,9 +1,5 @@
-use crate::hermite;
-use crate::legendre;
-
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::{GaussHermite, GaussLegendre, PI};
 
     #[test]

--- a/src/hermite/mod.rs
+++ b/src/hermite/mod.rs
@@ -18,6 +18,18 @@
 use crate::{DMatrixf64, PI};
 
 /// A Gauss-Hermite quadrature scheme.
+///
+/// These rules can integrate integrands of the form e^(-x^2) * f(x) over the domain (-∞, ∞).
+/// # Example
+/// Integrate e^(-x^2) * cos(x)
+/// ```
+/// # use gauss_quad::GaussHermite;
+/// # use approx::assert_abs_diff_eq;
+/// # use core::f64::consts::{E, PI};
+/// let quad = GaussHermite::init(20);
+/// let integral = quad.integrate(|x| x.cos());
+/// assert_abs_diff_eq!(integral, PI.sqrt() / E.powf(0.25), epsilon = 1e-14);
+/// ```
 pub struct GaussHermite {
     pub nodes: Vec<f64>,
     pub weights: Vec<f64>,

--- a/src/hermite/mod.rs
+++ b/src/hermite/mod.rs
@@ -1,3 +1,20 @@
+//! Numerical integration using Gauss-Hermite quadrature rules.
+//!
+//! These rules can integrate integrands of the form  
+//! e^(-x^2) * f(x)  
+//! over the domain (-∞, ∞).
+//!
+//! # Example
+//! Integrate x^2 * e^(-x^2)
+//! ```
+//! use gauss_quad::GaussHermite;
+//! use approx::assert_abs_diff_eq;
+//!
+//! let quad = GaussHermite::init(10);
+//! let integral = quad.integrate(|x| x.powi(2));
+//! assert_abs_diff_eq!(integral, core::f64::consts::PI.sqrt() / 2.0, epsilon = 1e-14);
+//! ```
+
 use crate::{DMatrixf64, PI};
 
 pub struct GaussHermite {
@@ -43,7 +60,7 @@ impl GaussHermite {
         (nodes, weights)
     }
 
-    /// Perform quadrature of integrand using given nodes x and weights w
+    /// Perform quadrature of e^(-x^2) * `integrand` over the domain (-∞, ∞).
     pub fn integrate<F>(&self, integrand: F) -> f64
     where
         F: Fn(f64) -> f64,

--- a/src/hermite/mod.rs
+++ b/src/hermite/mod.rs
@@ -1,6 +1,6 @@
-//! Numerical integration using Gauss-Hermite quadrature rules.
+//! Numerical integration using the Gauss-Hermite quadrature rule.
 //!
-//! These rules can integrate integrands of the form  
+//! This rule can integrate integrands of the form  
 //! e^(-x^2) * f(x)  
 //! over the domain (-∞, ∞).
 //!
@@ -26,8 +26,12 @@ use crate::{DMatrixf64, PI};
 /// # use gauss_quad::GaussHermite;
 /// # use approx::assert_abs_diff_eq;
 /// # use core::f64::consts::{E, PI};
+/// // initialize a Gauss-Hermite rule with 20 nodes
 /// let quad = GaussHermite::init(20);
+///
+/// // numerically integrate a function over (-∞, ∞) using the Gauss-Hermite rule
 /// let integral = quad.integrate(|x| x.cos());
+///
 /// assert_abs_diff_eq!(integral, PI.sqrt() / E.powf(0.25), epsilon = 1e-14);
 /// ```
 pub struct GaussHermite {
@@ -36,6 +40,7 @@ pub struct GaussHermite {
 }
 
 impl GaussHermite {
+    /// Initializes Gauss-Hermite quadrature rule of the given degree by computing the needed nodes and weights.
     pub fn init(deg: usize) -> GaussHermite {
         let (nodes, weights) = GaussHermite::nodes_and_weights(deg);
 

--- a/src/hermite/mod.rs
+++ b/src/hermite/mod.rs
@@ -7,7 +7,7 @@
 //! # Example
 //! Integrate x^2 * e^(-x^2)
 //! ```
-//! use gauss_quad::GaussHermite;
+//! use gauss_quad::hermite::GaussHermite;
 //! use approx::assert_abs_diff_eq;
 //!
 //! let quad = GaussHermite::init(10);

--- a/src/hermite/mod.rs
+++ b/src/hermite/mod.rs
@@ -17,6 +17,7 @@
 
 use crate::{DMatrixf64, PI};
 
+/// A Gauss-Hermite quadrature scheme.
 pub struct GaussHermite {
     pub nodes: Vec<f64>,
     pub weights: Vec<f64>,

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -1,3 +1,8 @@
+//! Numerical integration using Gauss-Jacobi quadrature rules.
+//! 
+//! These rules can integrate integrands of the form (1 - x)^alpha * (1 + x)^beta * f(x) over the domain [a, b],
+//! where f(x) is a smooth function on [a, b], alpha > -1 and beta > -1.
+
 use crate::gamma::gamma;
 use crate::DMatrixf64;
 
@@ -79,7 +84,9 @@ impl GaussJacobi {
         0.5 * (b - a)
     }
 
-    /// Perform quadrature of integrand using given nodes x and weights w
+    /// Perform quadrature of integrand from `a` to `b`. This will integrate  
+    /// (1 - x)^`alpha` * (1 + x)^`beta` * `integrand`  
+    /// where `alpha` and `beta` were given in the call to [`init`](Self::init).
     pub fn integrate<F>(&self, a: f64, b: f64, integrand: F) -> f64
     where
         F: Fn(f64) -> f64,

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -17,12 +17,12 @@ use crate::DMatrixf64;
 /// # use gauss_quad::GaussJacobi;
 /// # use approx::assert_abs_diff_eq;
 /// // initialize the quadrature rule
-/// let quad = GaussJacobi::init(10, 1.0, 1.0);
+/// let quad = GaussJacobi::init(100, 1.0, 1.0);
 ///
 /// // numerically integrate a function with singularities at -1 and 1
-/// let integral = quad.integrate(-1.0, 1.0, |x| x / ((1.0 - x) * (1.0 + x)));
+/// let integral = quad.integrate(-1.0, 1.0, |x| x * x / ((1.0 - x) * (1.0 + x)));
 ///
-/// assert_abs_diff_eq!(integral, 0.0, epsilon = 1e-14);
+/// assert_abs_diff_eq!(integral, 2.0 / 3.0, epsilon = 1e-3);
 /// ```
 pub struct GaussJacobi {
     pub nodes: Vec<f64>,

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -1,6 +1,6 @@
 //! Numerical integration using the Gauss-Jacobi quadrature rule.
 //!
-//! This rule can integrate integrands of the form (1 - x)^alpha * (1 + x)^beta * f(x) over the domain [-1, 1],
+//! This rule can integrate integrands of the form (1 + x)^alpha * (1 - x)^beta * f(x) over the domain [-1, 1],
 //! where f(x) is a smooth function on [1, 1], alpha > -1 and beta > -1.
 //! The domain can be changed to any [a, b] through a linear transformation (which is done in this module),
 //! and this enables the approximation of integrals with singularities at the end points of the domain.

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -4,6 +4,16 @@
 //! where f(x) is a smooth function on [1, 1], alpha > -1 and beta > -1.
 //! The domain can be changed to any [a, b] through a linear transformation (which is done in this module),
 //! and this enables the approximation of integrals with singularities at the end points of the domain.
+//!
+//! # Example
+//! ```
+//! use gauss_quad::jacobi::GaussJacobi;
+//! use approx::assert_abs_diff_eq;
+//!
+//! let quad = GaussJacobi::init(10, 0.0, -1.0 / 3.0);
+//! let integral = quad.integrate(-1.0, 1.0, |x| x.sin());
+//! assert_abs_diff_eq!(integral, -0.4207987746500829, epsilon = 1e-14);
+//! ```
 
 use crate::gamma::gamma;
 use crate::DMatrixf64;

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -16,13 +16,13 @@ use crate::DMatrixf64;
 /// ```
 /// # use gauss_quad::GaussJacobi;
 /// # use approx::assert_abs_diff_eq;
-/// // initialize the quadrature rule
-/// let quad = GaussJacobi::init(100, 1.0, 1.0);
+/// // initialize the quadrature rule.
+/// let quad = GaussJacobi::init(10, -0.5, 0.0);
 ///
-/// // numerically integrate a function with singularities at -1 and 1
-/// let integral = quad.integrate(-1.0, 1.0, |x| x * x / ((1.0 - x) * (1.0 + x)));
+/// // numerically integrate e^-x / sqrt(1 + x).
+/// let integral = quad.integrate(-1.0, 1.0, |x| (-x).exp());
 ///
-/// assert_abs_diff_eq!(integral, 2.0 / 3.0, epsilon = 1e-3);
+/// assert_abs_diff_eq!(integral, 2.460262013896155, epsilon = 1e-14);
 /// ```
 pub struct GaussJacobi {
     pub nodes: Vec<f64>,

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -16,13 +16,15 @@ use crate::DMatrixf64;
 /// ```
 /// # use gauss_quad::GaussJacobi;
 /// # use approx::assert_abs_diff_eq;
+/// # use core::f64::consts::E;
 /// // initialize the quadrature rule.
 /// let quad = GaussJacobi::init(10, -0.5, 0.0);
 ///
 /// // numerically integrate e^-x / sqrt(1 + x).
 /// let integral = quad.integrate(-1.0, 1.0, |x| (-x).exp());
 ///
-/// assert_abs_diff_eq!(integral, 2.460262013896155, epsilon = 1e-14);
+/// let dawson_function_of_sqrt_2 = 0.4525399074037225;
+/// assert_abs_diff_eq!(integral, 2.0 * E * dawson_function_of_sqrt_2, epsilon = 1e-14);
 /// ```
 pub struct GaussJacobi {
     pub nodes: Vec<f64>,

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -1,5 +1,5 @@
 //! Numerical integration using Gauss-Jacobi quadrature rules.
-//! 
+//!
 //! These rules can integrate integrands of the form (1 - x)^alpha * (1 + x)^beta * f(x) over the domain [a, b],
 //! where f(x) is a smooth function on [a, b], alpha > -1 and beta > -1.
 

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -11,7 +11,10 @@
 //! use approx::assert_abs_diff_eq;
 //!
 //! let quad = GaussJacobi::init(10, 0.0, -1.0 / 3.0);
+//!
+//! // numerically integrate sin(x) / (1 - x)^(1/3), a function with a singularity at x = 1.
 //! let integral = quad.integrate(-1.0, 1.0, |x| x.sin());
+//!
 //! assert_abs_diff_eq!(integral, -0.4207987746500829, epsilon = 1e-14);
 //! ```
 

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -1,14 +1,29 @@
 //! Numerical integration using the Gauss-Jacobi quadrature rule.
 //!
-//! This rule can integrate integrands of the form (1 - x)^alpha * (1 + x)^beta * f(x) over the domain [a, b],
-//! where f(x) is a smooth function on [a, b], alpha > -1 and beta > -1.
+//! This rule can integrate integrands of the form (1 - x)^alpha * (1 + x)^beta * f(x) over the domain [-1, 1],
+//! where f(x) is a smooth function on [1, 1], alpha > -1 and beta > -1.
+//! The domain can be changed to any [a, b] through a linear transformation (which is done in this module),
+//! and this enables the approximation of integrals with singularities at the end points of the domain.
 
 use crate::gamma::gamma;
 use crate::DMatrixf64;
 
 /// A Gauss-Jacobi quadrature scheme.
 ///
-/// These rules can integrate integrands of the form (1 - x)^alpha * (1 + x)^beta * f(x) over the domain [a, b].
+/// These rules can approximate integrals with singularities at the end points of the domain, [a, b].
+///
+/// # Examples
+/// ```
+/// # use gauss_quad::GaussJacobi;
+/// # use approx::assert_abs_diff_eq;
+/// // initialize the quadrature rule
+/// let quad = GaussJacobi::init(10, 1.0, 1.0);
+///
+/// // numerically integrate a function with singularities at -1 and 1
+/// let integral = quad.integrate(-1.0, 1.0, |x| x / ((1.0 - x) * (1.0 + x)));
+///
+/// assert_abs_diff_eq!(integral, 0.0, epsilon = 1e-14);
+/// ```
 pub struct GaussJacobi {
     pub nodes: Vec<f64>,
     pub weights: Vec<f64>,

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -6,6 +6,7 @@
 use crate::gamma::gamma;
 use crate::DMatrixf64;
 
+/// A Gauss-Jacobi quadrature scheme.
 pub struct GaussJacobi {
     pub nodes: Vec<f64>,
     pub weights: Vec<f64>,

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -1,18 +1,22 @@
-//! Numerical integration using Gauss-Jacobi quadrature rules.
+//! Numerical integration using the Gauss-Jacobi quadrature rule.
 //!
-//! These rules can integrate integrands of the form (1 - x)^alpha * (1 + x)^beta * f(x) over the domain [a, b],
+//! This rule can integrate integrands of the form (1 - x)^alpha * (1 + x)^beta * f(x) over the domain [a, b],
 //! where f(x) is a smooth function on [a, b], alpha > -1 and beta > -1.
 
 use crate::gamma::gamma;
 use crate::DMatrixf64;
 
 /// A Gauss-Jacobi quadrature scheme.
+///
+/// These rules can integrate integrands of the form (1 - x)^alpha * (1 + x)^beta * f(x) over the domain [a, b].
 pub struct GaussJacobi {
     pub nodes: Vec<f64>,
     pub weights: Vec<f64>,
 }
 
 impl GaussJacobi {
+    /// Initializes Gauss-Jacobi quadrature rule of the given degree by computing the nodes and weights
+    /// needed for the given `alpha` and `beta`.
     pub fn init(deg: usize, alpha: f64, beta: f64) -> GaussJacobi {
         let (nodes, weights) = GaussJacobi::nodes_and_weights(deg, alpha, beta);
 

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -1,6 +1,34 @@
+//! Numerical integration using the generalized Gauss-Laguerre quadrature rule.
+//! 
+//! A Gauss-Laguerre rule of degree `n` has nodes and weights chosen such that it
+//! can integrate polynomials of degree `2n - 1` exactly 
+//! with the weighing function `w(x, a) = x^a * e^(-x)` over the domain `[0, ∞)`.
+//! 
+//! # Examples
+//! ```
+//! use gauss_quad::GaussLaguerre;
+//! use approx::assert_abs_diff_eq;
+//! 
+//! let quad = GaussLaguerre::init(10, 0.0);
+//! let integral = quad.integrate(|x| x.powi(2));
+//! assert_abs_diff_eq!(integral, 2.0, epsilon = 1e-14);
+//! ```
+
 use crate::gamma::gamma;
 use crate::DMatrixf64;
 
+/// Use this struct to integrate functions with Gauss-Laguerre quadrature rules.
+/// 
+/// These rules can perform integrals with integrands of the form x^a * e^(-x) * f(x) over the domain [0, ∞).
+/// # Example
+/// Compute the factorial of 5:
+/// ```
+/// # use gauss_quad::GaussLaguerre;
+/// # use approx::assert_abs_diff_eq;
+/// let quad = GaussLaguerre::init(10, 0.0);
+/// let fact_5 = quad.integrate(|x| x.powi(5));
+/// assert_abs_diff_eq!(fact_5, 1.0 * 2.0 * 3.0 * 4.0 * 5.0, epsilon = 1e-11);
+/// ```
 pub struct GaussLaguerre {
     pub nodes: Vec<f64>,
     pub weights: Vec<f64>,
@@ -61,7 +89,7 @@ impl GaussLaguerre {
         (nodes, weights)
     }
 
-    /// Perform quadrature of integrand using given nodes x and weights w
+    /// Perform quadrature of given integrand over the domain `[0, ∞)`.
     pub fn integrate<F>(&self, integrand: F) -> f64
     where
         F: Fn(f64) -> f64,

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -6,7 +6,7 @@
 //!
 //! # Examples
 //! ```
-//! use gauss_quad::GaussLaguerre;
+//! use gauss_quad::laguerre::GaussLaguerre;
 //! use approx::assert_abs_diff_eq;
 //!
 //! let quad = GaussLaguerre::init(10, 1.0);

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -1,14 +1,14 @@
 //! Numerical integration using the generalized Gauss-Laguerre quadrature rule.
-//! 
+//!
 //! A Gauss-Laguerre rule of degree `n` has nodes and weights chosen such that it
-//! can integrate polynomials of degree `2n - 1` exactly 
+//! can integrate polynomials of degree `2n - 1` exactly
 //! with the weighing function `w(x, a) = x^a * e^(-x)` over the domain `[0, ∞)`.
-//! 
+//!
 //! # Examples
 //! ```
 //! use gauss_quad::GaussLaguerre;
 //! use approx::assert_abs_diff_eq;
-//! 
+//!
 //! let quad = GaussLaguerre::init(10, 0.0);
 //! let integral = quad.integrate(|x| x.powi(2));
 //! assert_abs_diff_eq!(integral, 2.0, epsilon = 1e-14);
@@ -18,7 +18,7 @@ use crate::gamma::gamma;
 use crate::DMatrixf64;
 
 /// Use this struct to integrate functions with Gauss-Laguerre quadrature rules.
-/// 
+///
 /// These rules can perform integrals with integrands of the form x^a * e^(-x) * f(x) over the domain [0, ∞).
 /// # Example
 /// Compute the factorial of 5:

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -17,7 +17,7 @@
 use crate::gamma::gamma;
 use crate::DMatrixf64;
 
-/// Use this struct to integrate functions with Gauss-Laguerre quadrature rules.
+/// A Gauss-Laguerre quadrature scheme.
 ///
 /// These rules can perform integrals with integrands of the form x^alpha * e^(-x) * f(x) over the domain [0, ∞).
 /// # Example

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -2,16 +2,16 @@
 //!
 //! A Gauss-Laguerre rule of degree `n` has nodes and weights chosen such that it
 //! can integrate polynomials of degree `2n - 1` exactly
-//! with the weighing function `w(x, a) = x^a * e^(-x)` over the domain `[0, ∞)`.
+//! with the weighing function `w(x, alpha) = x^alpha * e^(-x)` over the domain `[0, ∞)`.
 //!
 //! # Examples
 //! ```
 //! use gauss_quad::GaussLaguerre;
 //! use approx::assert_abs_diff_eq;
 //!
-//! let quad = GaussLaguerre::init(10, 0.0);
+//! let quad = GaussLaguerre::init(10, 1.0);
 //! let integral = quad.integrate(|x| x.powi(2));
-//! assert_abs_diff_eq!(integral, 2.0, epsilon = 1e-14);
+//! assert_abs_diff_eq!(integral, 6.0, epsilon = 1e-14);
 //! ```
 
 use crate::gamma::gamma;
@@ -19,7 +19,7 @@ use crate::DMatrixf64;
 
 /// Use this struct to integrate functions with Gauss-Laguerre quadrature rules.
 ///
-/// These rules can perform integrals with integrands of the form x^a * e^(-x) * f(x) over the domain [0, ∞).
+/// These rules can perform integrals with integrands of the form x^alpha * e^(-x) * f(x) over the domain [0, ∞).
 /// # Example
 /// Compute the factorial of 5:
 /// ```
@@ -89,7 +89,9 @@ impl GaussLaguerre {
         (nodes, weights)
     }
 
-    /// Perform quadrature of given integrand over the domain `[0, ∞)`.
+    /// Perform quadrature of  
+    /// x^`alpha` * e^(-x) * `integrand`  
+    /// over the domain `[0, ∞)`, where `alpha` was given in the call to [`init`](Self::init).
     pub fn integrate<F>(&self, integrand: F) -> f64
     where
         F: Fn(f64) -> f64,

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -25,8 +25,13 @@ use crate::DMatrixf64;
 /// ```
 /// # use gauss_quad::GaussLaguerre;
 /// # use approx::assert_abs_diff_eq;
+/// // initialize a Gauss-Laguerre rule with 10 nodes
 /// let quad = GaussLaguerre::init(10, 0.0);
+///
+/// // numerically evaluate this integral,
+/// // which is a definition of the gamma function
 /// let fact_5 = quad.integrate(|x| x.powi(5));
+///
 /// assert_abs_diff_eq!(fact_5, 1.0 * 2.0 * 3.0 * 4.0 * 5.0, epsilon = 1e-11);
 /// ```
 pub struct GaussLaguerre {
@@ -35,6 +40,8 @@ pub struct GaussLaguerre {
 }
 
 impl GaussLaguerre {
+    /// Initializes Gauss-Laguerre quadrature rule of the given degree by computing the nodes and weights
+    /// needed for the given `alpha` parameter.
     pub fn init(deg: usize, alpha: f64) -> GaussLaguerre {
         let (nodes, weights) = GaussLaguerre::nodes_and_weights(deg, alpha);
 

--- a/src/legendre/mod.rs
+++ b/src/legendre/mod.rs
@@ -1,5 +1,45 @@
+//! Numerical integration using the Gauss-Legendre quadrature rule.
+//!
+//! In Gauss-Legendre quadrature rules the integrand is evaluated at
+//! the unique points such that a degree `n` rule can integrate
+//! degree `2n - 1` degree polynomials exactly.
+//!
+//! Evaluation point x_i of a degree n rule is the i:th root
+//! of Legendre polynomial P_n and its weight is  
+//! w = 2 / ((1 - x_i)(P'_n(x_i))^2).
+//!
+//!
+//! # Example
+//! ```
+//! use gauss_quad::GaussLegendre;
+//! use approx::assert_abs_diff_eq;
+//!
+//! let quad = GaussLegendre::init(10);
+//! let integral = quad.integrate(-1.0, 1.0, |x| 0.125 * (63.0 * x.powi(5) - 70.0 * x.powi(3) + 15.0 * x));
+//! assert_abs_diff_eq!(integral, 0.0);
+//! ```
+
 use bogaert::NodeWeightPair;
 
+/// Use this struct to integrate functions with Gauss-Legendre quadrature
+/// # Examples
+/// Basic usage:
+/// ```
+/// # use gauss_quad::GaussLegendre;
+/// # use approx::assert_abs_diff_eq;
+/// let quad = GaussLegendre::init(3);
+/// let integral = quad.integrate(0.0, 1.0, |x| x * x - 1.0 / 3.0);
+/// assert_abs_diff_eq!(integral, 0.0);
+/// ```
+/// The nodes and weights are computed in `O(n)` time,
+/// so large quadrature rules are feasible:
+/// ```
+/// # use gauss_quad::GaussLegendre;
+/// # use approx::assert_abs_diff_eq;
+/// let quad = GaussLegendre::init(1_000_000);
+/// let integral = quad.integrate(-3.0, 3.0, |x| x.sin());
+/// assert_abs_diff_eq!(integral, 0.0);
+/// ```
 pub struct GaussLegendre {
     pub nodes: Vec<f64>,
     pub weights: Vec<f64>,

--- a/src/legendre/mod.rs
+++ b/src/legendre/mod.rs
@@ -23,7 +23,8 @@
 
 use bogaert::NodeWeightPair;
 
-/// Use this struct to integrate functions with Gauss-Legendre quadrature
+/// A Gauss-Legendre quadrature scheme.
+/// 
 /// # Examples
 /// Basic usage:
 /// ```

--- a/src/legendre/mod.rs
+++ b/src/legendre/mod.rs
@@ -24,7 +24,9 @@
 use bogaert::NodeWeightPair;
 
 /// A Gauss-Legendre quadrature scheme.
-/// 
+///
+/// These rules can integrate functions on the domain [a, b].
+///
 /// # Examples
 /// Basic usage:
 /// ```

--- a/src/legendre/mod.rs
+++ b/src/legendre/mod.rs
@@ -32,8 +32,12 @@ use bogaert::NodeWeightPair;
 /// ```
 /// # use gauss_quad::GaussLegendre;
 /// # use approx::assert_abs_diff_eq;
+/// // initialize a Gauss-Legendre rule with 3 nodes
 /// let quad = GaussLegendre::init(3);
+///
+/// // numerically integrate x^2 - 1/3 over the domain [0, 1]
 /// let integral = quad.integrate(0.0, 1.0, |x| x * x - 1.0 / 3.0);
+///
 /// assert_abs_diff_eq!(integral, 0.0);
 /// ```
 /// The nodes and weights are computed in `O(n)` time,
@@ -51,6 +55,7 @@ pub struct GaussLegendre {
 }
 
 impl GaussLegendre {
+    /// Initializes a Gauss-Legendre quadrature rule of the given degree by computing the needed nodes and weights.
     pub fn init(deg: usize) -> Self {
         let (nodes, weights) = Self::nodes_and_weights(deg);
 

--- a/src/legendre/mod.rs
+++ b/src/legendre/mod.rs
@@ -15,7 +15,9 @@
 //! use approx::assert_abs_diff_eq;
 //!
 //! let quad = GaussLegendre::init(10);
-//! let integral = quad.integrate(-1.0, 1.0, |x| 0.125 * (63.0 * x.powi(5) - 70.0 * x.powi(3) + 15.0 * x));
+//! let integral = quad.integrate(-1.0, 1.0,
+//!     |x| 0.125 * (63.0 * x.powi(5) - 70.0 * x.powi(3) + 15.0 * x)
+//! );
 //! assert_abs_diff_eq!(integral, 0.0);
 //! ```
 

--- a/src/legendre/mod.rs
+++ b/src/legendre/mod.rs
@@ -11,7 +11,7 @@
 //!
 //! # Example
 //! ```
-//! use gauss_quad::GaussLegendre;
+//! use gauss_quad::legendre::GaussLegendre;
 //! use approx::assert_abs_diff_eq;
 //!
 //! let quad = GaussLegendre::init(10);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,8 @@
 //! ```
 //! use gauss_quad::GaussLegendre;
 //! // This macro is used in these docs to compare floats.
-//! // The assertion succeeds if the two sides are within floating point error, or an optional epsilon.
+//! // The assertion succeeds if the two sides are within floating point error,
+//! // or an optional epsilon.
 //! use approx::assert_abs_diff_eq;
 //!
 //! // initialize the quadrature rule

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,16 +125,14 @@
 //! let integral = quad.integrate(left_bound, right_bound, |x| x * x);
 //! ```
 
-#![allow(dead_code)]
-#![allow(unused_imports)]
-
 use nalgebra::{Dynamic, Matrix, VecStorage};
 pub type DMatrixf64 = Matrix<f64, Dynamic, Dynamic, VecStorage<f64, Dynamic, Dynamic>>;
 #[doc(inline)]
 pub use std::f64::consts::PI;
 
 mod gamma;
-pub mod gaussian_quadrature;
+#[cfg(test)]
+mod gaussian_quadrature;
 pub mod hermite;
 pub mod jacobi;
 pub mod laguerre;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@
 //! let double_x = gauss_jacobi.integrate(c, d, |x| 2.0 * x);
 //!
 //! let gauss_laguerre = GaussLaguerre::init(degree, alpha);
-//! // no explicit domain, Gauss-Laguerre integration is done on the domain (-∞, ∞).
+//! // no explicit domain, Gauss-Laguerre integration is done on the domain [0, ∞).
 //! let piecewise = gauss_laguerre.integrate(|x| if x > 0.0 && x < 2.0 { x } else { 0.0 });
 //!
 //! let gauss_hermite = GaussHermite::init(degree);
@@ -71,7 +71,7 @@
 //! For example, the `GaussLaguerre` rule requires both a `degree` and an `alpha`
 //! parameter.
 //!
-//! `GaussLaguerre` is also defined as an improper integral over the domain (-∞, ∞).
+//! `GaussLaguerre` is also defined as an improper integral over the domain [0, ∞).
 //! This means no domain bounds are needed in the `integrate` call.
 //! ```
 //! # use gauss_quad::GaussLaguerre;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! ```
 //! use gauss_quad::GaussLegendre;
 //! // This macro is used in these docs to compare floats.
-//! // The assertion succeeds if the two sides are within floating point error.
+//! // The assertion succeeds if the two sides are within floating point error, or an optional epsilon.
 //! use approx::assert_abs_diff_eq;
 //!
 //! // initialize the quadrature rule

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,7 @@
 use nalgebra::{Dynamic, Matrix, VecStorage};
 pub type DMatrixf64 = Matrix<f64, Dynamic, Dynamic, VecStorage<f64, Dynamic, Dynamic>>;
 #[doc(inline)]
-pub use std::f64::consts::PI;
+pub use core::f64::consts::PI;
 
 mod gamma;
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,149 +1,129 @@
-/*!
-# gauss-quad
-
-**gauss-quad** is a Gaussian quadrature library for numerical integration.
-
-## Quadrature rules
-**gauss-quad** implements the following quadrature rules:
-* Gauss-Legendre
-* Gauss-Jacobi
-* Gauss-Laguerre
-* Gauss-Hermite
-* Midpoint
-* Simpson
-
-## Using **gauss-quad**
-To use any of the quadrature rules in your project, first initialize the rule with
-a specified degree and then you can use it for integration, e.g.:
-```rust
-extern crate gauss_quad;
-use gauss_quad::GaussLegendre;
-
-fn main() {
-
-    // initialize the quadrature rule
-    let degree = 10;
-    let quad = GaussLegendre::init(degree);
-
-    // use the rule to integrate a function
-    let left_bound = 0.0;
-    let right_bound = 1.0;
-    let integral = quad.integrate(left_bound, right_bound, |x| x * x);
-}
-```
-
-## Setting up a quadrature rule
-Using a quadrature rule takes two steps:
-1. Initialization
-2. Integration
-
-First, rules must be initialized using some specific input parameters.
-
-Then, you can integrate functions using those rules:
-```
-# extern crate gauss_quad;
-# use gauss_quad::*;
-# fn main() {
-#   let degree = 5;
-#   let alpha = 1.2;
-#   let beta = 1.2;
-#   let a = 0.0;
-#   let b = 1.0;
-#   let c = -10.;
-#   let d = 100.;
-let gauss_legendre = GaussLegendre::init(degree);
-// Integrate on the domain [a,b]
-let x_cubed = gauss_legendre.integrate(a, b, |x| x * x * x);
-
-let gauss_jacobi = GaussJacobi::init(degree, alpha, beta);
-// Integrate on the domain [c,d]
-let double_x = gauss_jacobi.integrate(a, b, |x| 2.0 * x);
-
-let gauss_laguerre = GaussLaguerre::init(degree, alpha);
-// no explicit domain, Gauss-Laguerre integration is done on the domain (-∞, ∞).
-let piecewise = gauss_laguerre.integrate(|x| if x > 0.0 && x < 2.0 { x } else { 0.0 });
-
-let gauss_hermite = GaussHermite::init(degree);
-// again, no explicit domain since integration is done over the domain (-∞, ∞).
-let constant = gauss_hermite.integrate(|x| if x > -1.0 && x < 1.0 { 2.0 } else { 1.0 });
-# }
-```
-
-## Specific quadrature rules
-Different rules may take different parameters.
-
-For example, the `GaussLaguerre` rule requires both a `degree` and an `alpha`
-parameter.
-
-`GaussLaguerre` is also defined as an improper integral over the domain (-∞, ∞).
-This means no domain bounds are needed in the `integrate` call.
-```rust
-extern crate gauss_quad;
-use gauss_quad::GaussLaguerre as quad_rule;
-
-fn main() {
-
-    // initialize the quadrature rule
-    let degree = 10;
-    let alpha = 0.5;
-    let quad = quad_rule::init(degree, alpha);
-
-    // use the rule to integrate a function
-    let integral = quad.integrate(|x| x * x);
-}
-```
-
-## Panics and errors
-Quadrature rules are only defined for a certain set of input values.
-For example, every rule is only defined for degrees where `degree > 1`.
-```should_panic
-# extern crate gauss_quad;
-# use gauss_quad::GaussLaguerre;
-# fn main() {
-    let degree = 1;
-    let quad = GaussLaguerre::init(degree, 0.1); // panics!
-# }
-```
-
-Specific rules may have other requirements.
-`GaussJacobi` for example, requires alpha and beta parameters larger than -1.0.
-```should_panic
-# extern crate gauss_quad;
-# use gauss_quad::GaussJacobi;
-# fn main() {
-    let degree = 10;
-    let alpha = 0.1;
-    let beta = -1.1;
-
-    let quad = GaussJacobi::init(degree, alpha, beta); // panics!
-# }
-```
-Make sure to read the specific quadrature rule's documentation before using it.
-
-Error handling is very simple: bad input values will cause the program to panic
-and abort with a short error message.
-
-## Passing functions to quadrature rules
-The `integrate` method expects functions of the form `Fn(f64) -> f64`, i.e. functions of
-one parameter.
-
-```rust
-extern crate gauss_quad;
-use gauss_quad::GaussLegendre;
-
-fn main() {
-
-    // initialize the quadrature rule
-    let degree = 10;
-    let quad = GaussLegendre::init(degree);
-
-    // use the rule to integrate a function
-    let left_bound = 0.0;
-    let right_bound = 1.0;
-    let integral = quad.integrate(left_bound, right_bound, |x| x * x);
-}
-```
-!*/
+//! # gauss-quad
+//!
+//! **gauss-quad** is a Gaussian quadrature library for numerical integration.
+//!
+//! ## Quadrature rules
+//! **gauss-quad** implements the following quadrature rules:
+//! * Gauss-Legendre
+//! * Gauss-Jacobi
+//! * Gauss-Laguerre
+//! * Gauss-Hermite
+//! * Midpoint
+//! * Simpson
+//!
+//! ## Using **gauss-quad**
+//! To use any of the quadrature rules in your project, first initialize the rule with
+//! a specified degree and then you can use it for integration, e.g.:
+//! ```
+//! use gauss_quad::GaussLegendre;
+//! // This macro is used in these docs to compare floats.
+//! // The assertion succeeds if the two sides are within floating point error.
+//! use approx::assert_abs_diff_eq;
+//!
+//! // initialize the quadrature rule
+//! let degree = 10;
+//! let quad = GaussLegendre::init(degree);
+//!
+//! // use the rule to integrate a function
+//! let left_bound = 0.0;
+//! let right_bound = 1.0;
+//! let integral = quad.integrate(left_bound, right_bound, |x| x * x);
+//! assert_abs_diff_eq!(integral, 1.0 / 3.0);
+//! ```
+//!
+//! ## Setting up a quadrature rule
+//! Using a quadrature rule takes two steps:
+//! 1. Initialization
+//! 2. Integration
+//!
+//! First, rules must be initialized using some specific input parameters.
+//!
+//! Then, you can integrate functions using those rules:
+//! ```
+//! # use gauss_quad::*;
+//! # let degree = 5;
+//! # let alpha = 1.2;
+//! # let beta = 1.2;
+//! # let a = 0.0;
+//! # let b = 1.0;
+//! # let c = -10.;
+//! # let d = 100.;
+//! let gauss_legendre = GaussLegendre::init(degree);
+//! // Integrate on the domain [a, b]
+//! let x_cubed = gauss_legendre.integrate(a, b, |x| x * x * x);
+//!
+//! let gauss_jacobi = GaussJacobi::init(degree, alpha, beta);
+//! // Integrate on the domain [c, d]
+//! let double_x = gauss_jacobi.integrate(c, d, |x| 2.0 * x);
+//!
+//! let gauss_laguerre = GaussLaguerre::init(degree, alpha);
+//! // no explicit domain, Gauss-Laguerre integration is done on the domain (-∞, ∞).
+//! let piecewise = gauss_laguerre.integrate(|x| if x > 0.0 && x < 2.0 { x } else { 0.0 });
+//!
+//! let gauss_hermite = GaussHermite::init(degree);
+//! // again, no explicit domain since integration is done over the domain (-∞, ∞).
+//! let constant = gauss_hermite.integrate(|x| if x > -1.0 && x < 1.0 { 2.0 } else { 1.0 });
+//! ```
+//!
+//! ## Specific quadrature rules
+//! Different rules may take different parameters.
+//!
+//! For example, the `GaussLaguerre` rule requires both a `degree` and an `alpha`
+//! parameter.
+//!
+//! `GaussLaguerre` is also defined as an improper integral over the domain (-∞, ∞).
+//! This means no domain bounds are needed in the `integrate` call.
+//! ```
+//! # use gauss_quad::GaussLaguerre;
+//! // initialize the quadrature rule
+//! let degree = 10;
+//! let alpha = 0.5;
+//! let quad = GaussLaguerre::init(degree, alpha);
+//!
+//! // use the rule to integrate a function
+//! let integral = quad.integrate(|x| x * x);
+//! ```
+//!
+//! ## Panics and errors
+//! Quadrature rules are only defined for a certain set of input values.
+//! For example, every rule is only defined for degrees where `degree > 1`.
+//! ```should_panic
+//! # use gauss_quad::GaussLaguerre;
+//! let degree = 1;
+//! let quad = GaussLaguerre::init(degree, 0.1); // panics!
+//! ```
+//!
+//! Specific rules may have other requirements.
+//! `GaussJacobi` for example, requires alpha and beta parameters larger than -1.0.
+//! ```should_panic
+//! # use gauss_quad::GaussJacobi;
+//! let degree = 10;
+//! let alpha = 0.1;
+//! let beta = -1.1;
+//!
+//! let quad = GaussJacobi::init(degree, alpha, beta); // panics!
+//! ```
+//! Make sure to read the specific quadrature rule's documentation before using it.
+//!
+//! Error handling is very simple: bad input values will cause the program to panic
+//! and abort with a short error message.
+//!
+//! ## Passing functions to quadrature rules
+//! The `integrate` method expects functions of the form `Fn(f64) -> f64`, i.e. functions of
+//! one parameter.
+//!
+//! ```
+//! # use gauss_quad::GaussLegendre;
+//!
+//! // initialize the quadrature rule
+//! let degree = 10;
+//! let quad = GaussLegendre::init(degree);
+//!
+//! // use the rule to integrate a function
+//! let left_bound = 0.0;
+//! let right_bound = 1.0;
+//! let integral = quad.integrate(left_bound, right_bound, |x| x * x);
+//! ```
 
 #![allow(dead_code)]
 #![allow(unused_imports)]

--- a/src/midpoint/mod.rs
+++ b/src/midpoint/mod.rs
@@ -1,44 +1,44 @@
-/*!
-Numerical integration using the midpoint rule.
-
-This is one of the simplest integration schemes.
-
-1. Divide the domain into equally sized sections.
-2. Find the function value at the midpoint of each section.
-3. The section's integral is approximated as a rectangle as wide as the section and as tall as the function
- value at the midpoint.
-
-```
-use gauss_quad::{Midpoint};
-use approx::assert_abs_diff_eq;
-
-use std::f64::consts::PI;
-
-let eps = 0.001;
-
-let n = 30;
-let quad = Midpoint::init(n);
-
-// integrate some functions
-let two_thirds = quad.integrate(-1.0, 1.0, |x| x * x);
-assert_abs_diff_eq!(two_thirds, 0.66666, epsilon = eps);
-
-let estimate_sin = quad.integrate(-PI, PI, |x| x.sin());
-assert_abs_diff_eq!(estimate_sin, 0.0, epsilon = eps);
-
-// some functions need more steps than others
-let m = 100;
-let better_quad = Midpoint::init(m);
-
-let piecewise = better_quad.integrate(-5.0, 5.0,
-                    |x| if x > 1.0 && x < 2.0 {
-                        (-x * x).exp()
-                    } else { 0.0 });
-
-assert_abs_diff_eq!(0.135257, piecewise, epsilon = eps);
-```
-
-!*/
+//! Numerical integration using the midpoint rule.
+//! 
+//! This is one of the simplest integration schemes.
+//! 
+//! 1. Divide the domain into equally sized sections.
+//! 2. Find the function value at the midpoint of each section.
+//! 3. The section's integral is approximated as a rectangle as wide as the section and as tall as the function
+//!  value at the midpoint.
+//! 
+//! ```
+//! use gauss_quad::Midpoint;
+//! use approx::assert_abs_diff_eq;
+//! 
+//! use std::f64::consts::PI;
+//! 
+//! let eps = 0.001;
+//! 
+//! let n = 30;
+//! let quad = Midpoint::init(n);
+//! 
+//! // integrate some functions
+//! let two_thirds = quad.integrate(-1.0, 1.0, |x| x * x);
+//! assert_abs_diff_eq!(two_thirds, 0.66666, epsilon = eps);
+//! 
+//! let estimate_sin = quad.integrate(-PI, PI, |x| x.sin());
+//! assert_abs_diff_eq!(estimate_sin, 0.0, epsilon = eps);
+//! 
+//! // some functions need more steps than others
+//! let m = 100;
+//! let better_quad = Midpoint::init(m);
+//! 
+//! let piecewise = better_quad.integrate(-5.0, 5.0, |x| 
+//!     if x > 1.0 && x < 2.0 {
+//!         (-x * x).exp()
+//!     } else {
+//!         0.0
+//!     }
+//! );
+//! 
+//! assert_abs_diff_eq!(0.135257, piecewise, epsilon = eps);
+//! ```
 
 #[derive(Debug, Clone)]
 /// A midpoint rule quadrature scheme.

--- a/src/midpoint/mod.rs
+++ b/src/midpoint/mod.rs
@@ -72,8 +72,7 @@ impl Midpoint {
 
     /// Make a set of evenly spaced nodes
     fn nodes(degree: usize) -> Vec<f64> {
-        let mut nodes = Vec::new();
-        nodes.reserve(degree);
+        let mut nodes = Vec::with_capacity(degree);
         for idx in 0..degree {
             nodes.push(idx as f64);
         }

--- a/src/midpoint/mod.rs
+++ b/src/midpoint/mod.rs
@@ -8,7 +8,7 @@
 //!  value at the midpoint.
 //!
 //! ```
-//! use gauss_quad::Midpoint;
+//! use gauss_quad::midpoint::Midpoint;
 //! use approx::assert_abs_diff_eq;
 //!
 //! use core::f64::consts::PI;

--- a/src/midpoint/mod.rs
+++ b/src/midpoint/mod.rs
@@ -11,7 +11,7 @@
 //! use gauss_quad::Midpoint;
 //! use approx::assert_abs_diff_eq;
 //!
-//! use std::f64::consts::PI;
+//! use core::f64::consts::PI;
 //!
 //! let eps = 0.001;
 //!

--- a/src/midpoint/mod.rs
+++ b/src/midpoint/mod.rs
@@ -1,42 +1,42 @@
 //! Numerical integration using the midpoint rule.
-//! 
+//!
 //! This is one of the simplest integration schemes.
-//! 
+//!
 //! 1. Divide the domain into equally sized sections.
 //! 2. Find the function value at the midpoint of each section.
 //! 3. The section's integral is approximated as a rectangle as wide as the section and as tall as the function
 //!  value at the midpoint.
-//! 
+//!
 //! ```
 //! use gauss_quad::Midpoint;
 //! use approx::assert_abs_diff_eq;
-//! 
+//!
 //! use std::f64::consts::PI;
-//! 
+//!
 //! let eps = 0.001;
-//! 
+//!
 //! let n = 30;
 //! let quad = Midpoint::init(n);
-//! 
+//!
 //! // integrate some functions
 //! let two_thirds = quad.integrate(-1.0, 1.0, |x| x * x);
 //! assert_abs_diff_eq!(two_thirds, 0.66666, epsilon = eps);
-//! 
+//!
 //! let estimate_sin = quad.integrate(-PI, PI, |x| x.sin());
 //! assert_abs_diff_eq!(estimate_sin, 0.0, epsilon = eps);
-//! 
+//!
 //! // some functions need more steps than others
 //! let m = 100;
 //! let better_quad = Midpoint::init(m);
-//! 
-//! let piecewise = better_quad.integrate(-5.0, 5.0, |x| 
+//!
+//! let piecewise = better_quad.integrate(-5.0, 5.0, |x|
 //!     if x > 1.0 && x < 2.0 {
 //!         (-x * x).exp()
 //!     } else {
 //!         0.0
 //!     }
 //! );
-//! 
+//!
 //! assert_abs_diff_eq!(0.135257, piecewise, epsilon = eps);
 //! ```
 

--- a/src/simpson/mod.rs
+++ b/src/simpson/mod.rs
@@ -1,42 +1,37 @@
-/*!
-Numerical integration using the Simpson rule.
-
-A popular quadrature rule (also known as Kepler's barrel rule). It can be derived
-in the simplest case by replacing the integrand with a parabola that has the same
-function values at the end points a & b, as well as the Simpson m=(a+b)/2, which
-results in the integral formula
-S(f) = (b-a)/6 * [ f(a) + 4f(m) + f(b) ]
-
-Dividing the interval \[a, b\] into N neighboring intervals of length h = (b-a)/N and
-applying the Simpson rule to each subinterval, the integral is given by
-
-S(f) = h/6 * [ f(a) + f(b) + 2*Sum_{k=1..N-1} f(x_k) + 4*Sum_{k=1..N} f( (x_{k-1} + x_k)/2 )]
-
-with x_k = a + k*h.
-
-
-
-```
-use gauss_quad::{Simpson};
-use approx::assert_abs_diff_eq;
-
-use std::f64::consts::PI;
-
-let eps = 0.001;
-
-let n = 10;
-let quad = Simpson::init(n);
-
-// integrate some functions
-let integrate_euler = quad.integrate(0.0, 1.0, |x| x.exp());
-assert_abs_diff_eq!(integrate_euler, 1.0_f64.exp() - 1.0, epsilon = eps);
-
-let integrate_sin = quad.integrate(-PI, PI, |x| x.sin());
-assert_abs_diff_eq!(integrate_sin, 0.0, epsilon = eps);
-
-```
-
-!*/
+//! Numerical integration using the Simpson rule.
+//!
+//! A popular quadrature rule (also known as Kepler's barrel rule). It can be derived
+//! in the simplest case by replacing the integrand with a parabola that has the same
+//! function values at the end points a & b, as well as the Simpson m=(a+b)/2, which
+//! results in the integral formula
+//! S(f) = (b-a)/6 * [ f(a) + 4f(m) + f(b) ]
+//!
+//! Dividing the interval \[a, b\] into N neighboring intervals of length h = (b-a)/N and
+//! applying the Simpson rule to each subinterval, the integral is given by
+//!
+//! S(f) = h/6 * [ f(a) + f(b) + 2*Sum_{k=1..N-1} f(x_k) + 4*Sum_{k=1..N} f( (x_{k-1} + x_k)/2 )]
+//!
+//! with x_k = a + k*h.
+//! 
+//! ```
+//! use gauss_quad::Simpson;
+//! use approx::assert_abs_diff_eq;
+//!
+//! use core::f64::consts::PI;
+//!
+//! let eps = 0.001;
+//!
+//! let n = 10;
+//! let quad = Simpson::init(n);
+//!
+//! // integrate some functions
+//! let integrate_euler = quad.integrate(0.0, 1.0, |x| x.exp());
+//! assert_abs_diff_eq!(integrate_euler, 1.0_f64.exp() - 1.0, epsilon = eps);
+//!
+//! let integrate_sin = quad.integrate(-PI, PI, |x| x.sin());
+//! assert_abs_diff_eq!(integrate_sin, 0.0, epsilon = eps);
+//!
+//! ```
 
 #[derive(Debug, Clone)]
 /// A Simpson rule quadrature scheme.

--- a/src/simpson/mod.rs
+++ b/src/simpson/mod.rs
@@ -33,7 +33,6 @@
 //!
 //! ```
 
-
 /// A Simpson rule quadrature scheme.
 /// ```
 /// # use gauss_quad::Simpson;
@@ -60,8 +59,7 @@ impl Simpson {
 
     /// Generate vector of indices for the subintervals
     fn nodes(degree: usize) -> Vec<f64> {
-        let mut nodes = Vec::new();
-        nodes.reserve(degree);
+        let mut nodes = Vec::with_capacity(degree);
         for idx in 0..degree {
             nodes.push(idx as f64);
         }

--- a/src/simpson/mod.rs
+++ b/src/simpson/mod.rs
@@ -7,7 +7,7 @@ function values at the end points a & b, as well as the Simpson m=(a+b)/2, which
 results in the integral formula
 S(f) = (b-a)/6 * [ f(a) + 4f(m) + f(b) ]
 
-Dividing the interval [a,b] into N neighboring intervals of length h = (b-a)/N and
+Dividing the interval \[a, b\] into N neighboring intervals of length h = (b-a)/N and
 applying the Simpson rule to each subinterval, the integral is given by
 
 S(f) = h/6 * [ f(a) + f(b) + 2*Sum_{k=1..N-1} f(x_k) + 4*Sum_{k=1..N} f( (x_{k-1} + x_k)/2 )]

--- a/src/simpson/mod.rs
+++ b/src/simpson/mod.rs
@@ -12,7 +12,7 @@
 //! S(f) = h/6 * [ f(a) + f(b) + 2*Sum_{k=1..N-1} f(x_k) + 4*Sum_{k=1..N} f( (x_{k-1} + x_k)/2 )]
 //!
 //! with x_k = a + k*h.
-//! 
+//!
 //! ```
 //! use gauss_quad::Simpson;
 //! use approx::assert_abs_diff_eq;
@@ -36,16 +36,12 @@
 #[derive(Debug, Clone)]
 /// A Simpson rule quadrature scheme.
 /// ```
-/// # extern crate gauss_quad;
 /// # use gauss_quad::Simpson;
-/// # fn main() {
-/// #
 /// // initialize a Simpson rule with 100 subintervals
 /// let quad: Simpson = Simpson::init(100);
 ///
 /// // numerically integrate a function from -1.0 to 1.0 using the Simpson rule
 /// let approx = quad.integrate(-1.0, 1.0, |x| x * x);
-/// # }
 /// ```
 pub struct Simpson {
     /// The dimensionless Simpsons

--- a/src/simpson/mod.rs
+++ b/src/simpson/mod.rs
@@ -14,7 +14,7 @@
 //! with x_k = a + k*h.
 //!
 //! ```
-//! use gauss_quad::Simpson;
+//! use gauss_quad::simpson::Simpson;
 //! use approx::assert_abs_diff_eq;
 //!
 //! use core::f64::consts::PI;


### PR DESCRIPTION
Feel free to ignore this PR as this might be something you disagree with or want to do yourself, but I have 

- Removed the use of language features in the documentation that used to be necessary (e.g. `extern crate ...` when importing a crate, or `fn main() { ... }` in tests) 
- Added docstrings to all the submodules (`laguerre`, `hermite`, etc.) that try to adhere to the style of the crate, and contain an example that is tested.
- Added docstrings to all the quadrature structs (e.g. `GaussHermite`) that contain an example that is tested. 
- Removed two unused imports that were never exported into the API or used internally in the `gaussian_quadrature` module, so that the two `#![allow(...)]` directives are no longer needed. Since it doesn't export anything rustdoc just generated a link to an empty page, so I made that module private.
- Changed text links in the docs (e.g. ht<span>tp://</span>www.website.com) into direct links (e.g. \<ht<span>tp://</span>www.website.com\>) to fix a rustdoc warning.
- Corrected a minor error in the documentation of the domain of Gauss-Laguerre quadrature (I changed `(-inf, inf)` to `[0, inf)`).
- Added short explanation of  `assert_abs_diff_eq` the first time it is used in the docs.

This PR only touches documentation related things, the API and the implementations of the quadrature rules are unchanged.