### PR TITLE
Derive `Clone`, `Debug` and `PartialEq` for all quadrature structs

### DIFF
--- a/src/hermite/mod.rs
+++ b/src/hermite/mod.rs
@@ -1,5 +1,6 @@
 use crate::{DMatrixf64, PI};
 
+#[derive(Debug, Clone, PartialEq)]
 pub struct GaussHermite {
     pub nodes: Vec<f64>,
     pub weights: Vec<f64>,

--- a/src/hermite/mod.rs
+++ b/src/hermite/mod.rs
@@ -79,4 +79,13 @@ mod tests {
             approx::assert_abs_diff_eq!(*w_val, w[i], epsilon = 1e-15);
         }
     }
+
+    #[test]
+    fn check_derives() {
+        let quad = GaussHermite::init(10);
+        let quad_clone = quad.clone();
+        assert_eq!(quad, quad_clone);
+        let other_quad = GaussHermite::init(3);
+        assert_ne!(quad, other_quad);
+    }
 }

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -1,6 +1,7 @@
 use crate::gamma::gamma;
 use crate::DMatrixf64;
 
+#[derive(Debug, Clone, PartialEq)]
 pub struct GaussJacobi {
     pub nodes: Vec<f64>,
     pub weights: Vec<f64>,

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -302,4 +302,13 @@ mod tests {
             approx::assert_abs_diff_eq!(*w_val, w[i], epsilon = 1e-10);
         }
     }
+
+    #[test]
+    fn check_derives() {
+        let quad = GaussJacobi::init(10, 0.0, 1.0);
+        let quad_clone = quad.clone();
+        assert_eq!(quad, quad_clone);
+        let other_quad = GaussJacobi::init(10, 1.0, 0.0);
+        assert_ne!(quad, other_quad);
+    }
 }

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -160,4 +160,13 @@ mod tests {
             approx::assert_abs_diff_eq!(*w_val, w[i], epsilon = 1e-14);
         }
     }
+
+    #[test]
+    fn check_derives() {
+        let quad = GaussLaguerre::init(10, 1.0);
+        let quad_clone = quad.clone();
+        assert_eq!(quad, quad_clone);
+        let other_quad = GaussLaguerre::init(10, 2.0);
+        assert_ne!(quad, other_quad);
+    }
 }

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -1,6 +1,7 @@
 use crate::gamma::gamma;
 use crate::DMatrixf64;
 
+#[derive(Debug, Clone, PartialEq)]
 pub struct GaussLaguerre {
     pub nodes: Vec<f64>,
     pub weights: Vec<f64>,

--- a/src/legendre/mod.rs
+++ b/src/legendre/mod.rs
@@ -1,5 +1,6 @@
 use bogaert::NodeWeightPair;
 
+#[derive(Debug, Clone, PartialEq)]
 pub struct GaussLegendre {
     pub nodes: Vec<f64>,
     pub weights: Vec<f64>,

--- a/src/legendre/mod.rs
+++ b/src/legendre/mod.rs
@@ -252,6 +252,15 @@ mod tests {
             approx::assert_abs_diff_eq!(*w_val, w[i]);
         }
     }
+
+    #[test]
+    fn check_derives() {
+        let quad = GaussLegendre::init(10);
+        let quad_clone = quad.clone();
+        assert_eq!(quad, quad_clone);
+        let other_quad = GaussLegendre::init(3);
+        assert_ne!(quad, other_quad);
+    }
 }
 
 #[rustfmt::skip]

--- a/src/midpoint/mod.rs
+++ b/src/midpoint/mod.rs
@@ -40,7 +40,6 @@ assert_abs_diff_eq!(0.135257, piecewise, epsilon = eps);
 
 !*/
 
-#[derive(Debug, Clone)]
 /// A midpoint rule quadrature scheme.
 /// ```
 /// # extern crate gauss_quad;
@@ -54,6 +53,7 @@ assert_abs_diff_eq!(0.135257, piecewise, epsilon = eps);
 /// let approx = quad.integrate(-1.0, 1.0, |x| x * x);
 /// # }
 /// ```
+#[derive(Debug, Clone, PartialEq)]
 pub struct Midpoint {
     /// The dimensionless midpoints
     nodes: Vec<f64>,

--- a/src/midpoint/mod.rs
+++ b/src/midpoint/mod.rs
@@ -108,4 +108,13 @@ mod tests {
         let integral = quad.integrate(0.0, 1.0, |x| x * x);
         approx::assert_abs_diff_eq!(integral, 1.0 / 3.0, epsilon = 0.0001);
     }
+
+    #[test]
+    fn check_derives() {
+        let quad = Midpoint::init(10);
+        let quad_clone = quad.clone();
+        assert_eq!(quad, quad_clone);
+        let other_quad = Midpoint::init(3);
+        assert_ne!(quad, other_quad);
+    }
 }

--- a/src/simpson/mod.rs
+++ b/src/simpson/mod.rs
@@ -35,10 +35,8 @@ let integrate_sin = quad.integrate(-PI, PI, |x| x.sin());
 assert_abs_diff_eq!(integrate_sin, 0.0, epsilon = eps);
 
 ```
-
 !*/
 
-#[derive(Debug, Clone)]
 /// A Simpson rule quadrature scheme.
 /// ```
 /// # extern crate gauss_quad;
@@ -52,6 +50,7 @@ assert_abs_diff_eq!(integrate_sin, 0.0, epsilon = eps);
 /// let approx = quad.integrate(-1.0, 1.0, |x| x * x);
 /// # }
 /// ```
+#[derive(Debug, Clone, PartialEq)]
 pub struct Simpson {
     /// The dimensionless Simpsons
     nodes: Vec<f64>,

--- a/src/simpson/mod.rs
+++ b/src/simpson/mod.rs
@@ -121,4 +121,13 @@ mod tests {
         let integral = quad.integrate(0.0, 1.0, |x| x * x);
         approx::assert_abs_diff_eq!(integral, 1.0 / 3.0, epsilon = 0.0001);
     }
+
+    #[test]
+    fn check_derives() {
+        let quad = Simpson::init(10);
+        let quad_clone = quad.clone();
+        assert_eq!(quad, quad_clone);
+        let other_quad = Simpson::init(3);
+        assert_ne!(quad, other_quad);
+    }
 }


### PR DESCRIPTION
This PR is my suggestion for #23, it unifies what traits are derived between all the different quadrature rules to `Debug`, `Clone` and `PartialEq`.

# Reasoning
- `Debug`: in case someone using the library wants to print out the nodes and weights for debugging, this makes it very simple: just `println!("{quad_rule:?}");`.
- `Clone`: it's cheaper to clone an already initialized quadrature rule than computing all the nodes and weights again.
- `PartialEq`: easy way to check if two different instantiations of the same rule are the same. Currently only some rules can be checked for equality by checking if all the member fields are the same.