### PR TITLE
Extend authors list, add category mathematics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "gauss-quad"
 version = "0.1.7"
-authors = ["DomiDre <dominiquedresen@gmail.com>"]
+authors = ["DomiDre <dominiquedresen@gmail.com>", "Johanna Sörngård (jsorngard@gmail.com)"]
 keywords = ["gaussian", "quadrature", "numerics", "integration"]
+categories = ["Mathematics"]
 edition = "2018"
 description = "Library for applying Gaussian quadrature to integrate a function"
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
Add categories to Config.toml as desired by the Rust API guide line, see #27 

Also extended the authors list on the same go

@JSorngard  I copied the name and email from another crate of yours, hope that's fine