### PR TITLE
Add # Panic in docstrings  to fn that can panic

### DIFF
--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -48,6 +48,9 @@ pub struct GaussJacobi {
 impl GaussJacobi {
     /// Initializes Gauss-Jacobi quadrature rule of the given degree by computing the nodes and weights
     /// needed for the given `alpha` and `beta`.
+    /// 
+    /// # Panics
+    /// Panics if degree of quadrature is smaller than 2, or if alpha or beta are smaller than -1
     pub fn init(deg: usize, alpha: f64, beta: f64) -> GaussJacobi {
         let (nodes, weights) = GaussJacobi::nodes_and_weights(deg, alpha, beta);
 
@@ -56,6 +59,9 @@ impl GaussJacobi {
 
     /// Apply Golub-Welsch algorithm to determine Gauss-Jacobi nodes & weights
     /// see Gil, Segura, Temme - Numerical Methods for Special Functions
+    /// 
+    /// # Panics
+    /// Panics if degree of quadrature is smaller than 2, or if alpha or beta are smaller than -1
     pub fn nodes_and_weights(deg: usize, alpha: f64, beta: f64) -> (Vec<f64>, Vec<f64>) {
         if alpha < -1.0 || beta < -1.0 {
             panic!("Gauss-Jacobi quadrature needs alpha > -1.0 and beta > -1.0");

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -43,6 +43,9 @@ pub struct GaussLaguerre {
 impl GaussLaguerre {
     /// Initializes Gauss-Laguerre quadrature rule of the given degree by computing the nodes and weights
     /// needed for the given `alpha` parameter.
+    /// 
+    /// # Panics
+    /// Panics if degree of quadrature is smaller than 2, or if alpha is smaller than -1
     pub fn init(deg: usize, alpha: f64) -> GaussLaguerre {
         let (nodes, weights) = GaussLaguerre::nodes_and_weights(deg, alpha);
 
@@ -56,6 +59,9 @@ impl GaussLaguerre {
     /// (2n+1) on the diagonal & -(n+1) on the off-diagonal (n = row number).
     /// Root & weight finding are equivalent to eigenvalue problem.
     /// see Gil, Segura, Temme - Numerical Methods for Special Functions
+    /// 
+    /// # Panics
+    /// Panics if degree of quadrature is smaller than 2, or if alpha is smaller than -1
     pub fn nodes_and_weights(deg: usize, alpha: f64) -> (Vec<f64>, Vec<f64>) {
         if alpha < -1.0 {
             panic!("Gauss-Laguerre quadrature needs alpha > -1.0");


### PR DESCRIPTION
So far I think it was only missing in Gauss Jacobi & Laguerre. Probably not so nice that the panic docstring is the same for init and nodes_and_weights but that should probably fade once the API gets rehauled.