### PR TITLE
Add a `serde` feature that implements `Serialize` and `Deserialize` for the quadrature rule structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,7 @@ version = "0.1.7"
 dependencies = [
  "approx",
  "nalgebra",
+ "serde",
 ]
 
 [[package]]
@@ -64,7 +65,7 @@ checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -114,18 +115,18 @@ checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -146,6 +147,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.192"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.192"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "simba"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +184,17 @@ name = "syn"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ crate-type = ["lib", "cdylib"]
 
 [dependencies]
 nalgebra = "0.30"
+serde = {version = "1.0.192", default_features = true, features = ["alloc", "derive"], optional = true}
 
 [dev-dependencies]
 approx = "0.5.1"
+
+[features]
+serde = ["dep:serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ approx = "0.5.1"
 
 [features]
 serde = ["dep:serde"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["lib", "cdylib"]
 
 [dependencies]
 nalgebra = "0.30"
-serde = {version = "1.0.192", default_features = true, features = ["alloc", "derive"], optional = true}
+serde = {version = "1.0.192", default_features = false, features = ["alloc", "derive"], optional = true}
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/src/hermite/mod.rs
+++ b/src/hermite/mod.rs
@@ -35,6 +35,7 @@ use crate::{DMatrixf64, PI};
 /// assert_abs_diff_eq!(integral, PI.sqrt() / E.powf(0.25), epsilon = 1e-14);
 /// ```
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GaussHermite {
     pub nodes: Vec<f64>,
     pub weights: Vec<f64>,

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -40,6 +40,7 @@ use crate::DMatrixf64;
 /// assert_abs_diff_eq!(integral, 2.0 * E * dawson_function_of_sqrt_2, epsilon = 1e-14);
 /// ```
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GaussJacobi {
     pub nodes: Vec<f64>,
     pub weights: Vec<f64>,

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -35,6 +35,7 @@ use crate::DMatrixf64;
 /// assert_abs_diff_eq!(fact_5, 1.0 * 2.0 * 3.0 * 4.0 * 5.0, epsilon = 1e-11);
 /// ```
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GaussLaguerre {
     pub nodes: Vec<f64>,
     pub weights: Vec<f64>,

--- a/src/legendre/mod.rs
+++ b/src/legendre/mod.rs
@@ -50,6 +50,7 @@ use bogaert::NodeWeightPair;
 /// assert_abs_diff_eq!(integral, 0.0);
 /// ```
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GaussLegendre {
     pub nodes: Vec<f64>,
     pub weights: Vec<f64>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,8 +126,8 @@
 //! let integral = quad.integrate(left_bound, right_bound, |x| x * x);
 //! ```
 //! # Features
-//! `serde`: implements the [`Serialize`](serde::Serialize) and [`Deserialize`](serde::Deserialize) traits for
-//! the quatrature structs.
+//! `serde`: implements the [`Serialize`](serde::Serialize) and [`Deserialize`](serde::Deserialize) traits from
+//! the [`serde`](https://crates.io/crates/serde) crate for the quatrature rule structs.
 
 use nalgebra::{Dynamic, Matrix, VecStorage};
 pub type DMatrixf64 = Matrix<f64, Dynamic, Dynamic, VecStorage<f64, Dynamic, Dynamic>>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,9 @@
 //! let right_bound = 1.0;
 //! let integral = quad.integrate(left_bound, right_bound, |x| x * x);
 //! ```
+//! # Features
+//! `serde`: implements the [`Serialize`](serde::Serialize) and [`Deserialize`](serde::Deserialize) traits for
+//! the quatrature structs.
 
 use nalgebra::{Dynamic, Matrix, VecStorage};
 pub type DMatrixf64 = Matrix<f64, Dynamic, Dynamic, VecStorage<f64, Dynamic, Dynamic>>;

--- a/src/midpoint/mod.rs
+++ b/src/midpoint/mod.rs
@@ -54,6 +54,7 @@
 /// # }
 /// ```
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Midpoint {
     /// The dimensionless midpoints
     nodes: Vec<f64>,

--- a/src/simpson/mod.rs
+++ b/src/simpson/mod.rs
@@ -43,6 +43,7 @@
 /// let approx = quad.integrate(-1.0, 1.0, |x| x * x);
 /// ```
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Simpson {
     /// The dimensionless Simpsons
     nodes: Vec<f64>,


### PR DESCRIPTION
Also documents the feature.

Resolves #37.