### PR TITLE
Implement the unified memory API using a macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,16 @@
 
 This update is mostly about changing the API to adhere to the [Rust API guidelines](https://rust-lang.github.io/api-guidelines/about.html).
 
+## Breaking changes
+
  - Changed the name of all constructors from `init` to `new`.
- - Added the `serde` feature which implements the `Serialize` and `Deserialize` traits from [`serde`](https://crates.io/crates/serde) for all quadrature rule structs.
+ - The fields of the structs are now private.
+ - A set of functions have been implemented that access the node and weight data of the quadrature rule structs in various ways.
+ - The crate no longer exports the `DMatrixf64` type alias.
+ - The crate no longer re-exports the `core::f64::consts::PI` constant.
 
-## Minor changes
+## Other changes
 
+- Added the `serde` feature which implements the `Serialize` and `Deserialize` traits from [`serde`](https://crates.io/crates/serde) for all quadrature rule structs.
+- The quadrature rule structs now store the nodes and weights together in a single allocation. This slightly speeds up integration.
  - Fixed a sign error in the documentation for `GaussJacobi`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,23 +50,11 @@ checksum = "307ed9b18cc2423f29e83f84fd23a8e73628727990181f18641a8b5dc2ab1caa"
 dependencies = [
  "approx",
  "matrixmultiply",
- "nalgebra-macros",
  "num-complex",
  "num-rational",
  "num-traits",
  "simba",
  "typenum",
-]
-
-[[package]]
-name = "nalgebra-macros"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91761aed67d03ad966ef783ae962ef9bbaca728d2dd7ceb7939ec110fffad998"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -164,7 +152,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn",
 ]
 
 [[package]]
@@ -178,17 +166,6 @@ dependencies = [
  "num-traits",
  "paste",
  "wide",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bytemuck"
-version = "1.12.3"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaa3a8d9a1ca92e282c96a32d6511b695d7d994d1d102ba85d279f9b2756947f"
+checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
 
 [[package]]
 name = "gauss-quad"
@@ -34,18 +34,19 @@ dependencies = [
 
 [[package]]
 name = "matrixmultiply"
-version = "0.3.2"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add85d4dd35074e6fedc608f8c8f513a3548619a9024b751949ef0e8e45a4d84"
+checksum = "7574c1cf36da4798ab73da5b215bbf444f50718207754cb522201d78d1cd0ff2"
 dependencies = [
+ "autocfg",
  "rawpointer",
 ]
 
 [[package]]
 name = "nalgebra"
-version = "0.30.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb2d0de08694bed883320212c18ee3008576bfe8c306f4c3c4a58b4876998be"
+checksum = "307ed9b18cc2423f29e83f84fd23a8e73628727990181f18641a8b5dc2ab1caa"
 dependencies = [
  "approx",
  "matrixmultiply",
@@ -59,20 +60,20 @@ dependencies = [
 
 [[package]]
 name = "nalgebra-macros"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
+checksum = "91761aed67d03ad966ef783ae962ef9bbaca728d2dd7ceb7939ec110fffad998"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "num-complex"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
+checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
 dependencies = [
  "num-traits",
 ]
@@ -100,18 +101,18 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "proc-macro2"
@@ -139,27 +140,27 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "safe_arch"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "794821e4ccb0d9f979512f9c1973480123f9bd62a90d74ab0f9426fcf8f4a529"
+checksum = "f398075ce1e6a179b46f51bd88d0598b92b00d3551f1a2d4ac49e771b56ac354"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.192"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.192"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -168,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "simba"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3fd720c48c53cace224ae62bef1bbff363a70c68c4802a78b5cc6159618176"
+checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
 dependencies = [
  "approx",
  "num-complex",
@@ -181,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -203,21 +204,21 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "wide"
-version = "0.7.5"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae41ecad2489a1655c8ef8489444b0b113c0a0c795944a3572a0931cf7d2525c"
+checksum = "c68938b57b33da363195412cfc5fc37c9ed49aa9cfe2156fde64b8d2c9498242"
 dependencies = [
  "bytemuck",
  "safe_arch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/domidre/gauss-quad"
 crate-type = ["lib", "cdylib"]
 
 [dependencies]
-nalgebra = "0.32"
+nalgebra = {version = "0.32", default_features = false, features = ["std"]}
 serde = {version = "1.0.192", default_features = false, features = ["alloc", "derive"], optional = true}
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/domidre/gauss-quad"
 crate-type = ["lib", "cdylib"]
 
 [dependencies]
-nalgebra = "0.30"
+nalgebra = "0.32"
 serde = {version = "1.0.192", default_features = false, features = ["alloc", "derive"], optional = true}
 
 [dev-dependencies]

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -73,7 +73,7 @@ macro_rules! impl_data_api {
     };
 }
 
-/// This macro defines the iterators used by the functions defined in the macro `impl_data_api`.
+/// This macro defines the iterators used by the functions defined in the macro [`impl_data_api!`].
 /// It takes in the names of the same structs as that macro,
 /// plus the name of the iterator that should be returned by the [`IntoIterator`] implementation.
 /// These iterators can only be created in the module where the macro is called

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -13,10 +13,7 @@ macro_rules! impl_data_api {
         $quadrature_rule_weights:ident,
         // The name that the iterator returned when calling the `iter` function should have,
         // e.g. GaussLegendreIter.
-        $quadrature_rule_iter:ident,
-        // The name that the iterator returned by the `into_iter` function of the IntoIterator
-        // trait should have, e.g. GaussLegendreIntoIter.
-        $quadrature_rule_into_iter:ident
+        $quadrature_rule_iter:ident
     ) => {
         // The functions in this impl block all have an #[inline] directive because they are trivial.
         impl $quadrature_rule {
@@ -75,6 +72,13 @@ macro_rules! impl_data_api {
                 self.nodes.len()
             }
         }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! impl_iterators {
+    ($quadrature_rule:ident, $quadrature_rule_nodes:ident, $quadrature_rule_weights:ident, $quadrature_rule_iter:ident, $quadrature_rule_into_iter:ident) => {
 
         slice_iter_impl! {$quadrature_rule_nodes}
         slice_iter_impl! {$quadrature_rule_weights}
@@ -85,8 +89,8 @@ macro_rules! impl_data_api {
         #[derive(Debug, Clone)]
         #[must_use = "iterators are lazy and do nothing unless consumed"]
         pub struct $quadrature_rule_iter<'a> {
-            node_iter: $quadrature_rule_nodes<'a>,
-            weight_iter: $quadrature_rule_weights<'a>,
+            pub(super) node_iter: $quadrature_rule_nodes<'a>,
+            pub(super) weight_iter: $quadrature_rule_weights<'a>,
         }
 
         impl<'a> ::core::iter::Iterator for $quadrature_rule_iter<'a> {
@@ -114,10 +118,10 @@ macro_rules! impl_data_api {
         #[derive(Debug, Clone, PartialEq)]
         #[must_use = "iterators are lazy and do nothing unless consumed"]
         pub struct $quadrature_rule_into_iter {
-            nodes: Vec<f64>,
-            weights: Vec<f64>,
-            index: usize,
-            back_index: usize,
+            pub(super) nodes: Vec<f64>,
+            pub(super) weights: Vec<f64>,
+            pub(super) index: usize,
+            pub(super) back_index: usize,
         }
 
         impl ::core::iter::Iterator for $quadrature_rule_into_iter {
@@ -197,7 +201,7 @@ macro_rules! slice_iter_impl {
         #[derive(Debug, Clone)]
         #[must_use = "iterators are lazy and do nothing unless consumed"]
         pub struct $slice_iter<'a> {
-            iter: ::core::slice::Iter<'a, f64>,
+            pub(super) iter: ::core::slice::Iter<'a, f64>,
         }
 
         impl<'a> ::core::iter::Iterator for $slice_iter<'a> {

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -79,8 +79,99 @@ macro_rules! impl_iterators {
         $quadrature_rule_iter:ident,
         $quadrature_rule_into_iter:ident
     ) => {
-        slice_map_iter_impl! {$quadrature_rule_nodes}
-        slice_map_iter_impl! {$quadrature_rule_weights}
+        // region: QuadratureRuleNodes
+
+        /// An iterator over the nodes of the quadrature rule.
+        #[derive(Debug, Clone)]
+        #[must_use = "iterators are lazy and do nothing unless consumed"]
+        pub struct $quadrature_rule_nodes<'a> {
+            iter_map: ::std::iter::Map<
+                ::core::slice::Iter<'a, (Node, Weight)>,
+                fn(&'a (Node, Weight)) -> &'a Node,
+            >,
+        }
+
+        impl<'a> $quadrature_rule_nodes<'a> {
+            pub(super) fn new(
+                iter_map: ::std::iter::Map<
+                    ::core::slice::Iter<'a, (Node, Weight)>,
+                    fn(&'a (Node, Weight)) -> &'a Node,
+                >,
+            ) -> Self {
+                Self { iter_map }
+            }
+        }
+
+        impl<'a> ::core::iter::Iterator for $quadrature_rule_nodes<'a> {
+            type Item = &'a Node;
+            fn next(&mut self) -> Option<Self::Item> {
+                self.iter_map.next()
+            }
+
+            #[inline]
+            fn size_hint(&self) -> (usize, Option<usize>) {
+                self.iter_map.size_hint()
+            }
+        }
+
+        impl<'a> ::core::iter::DoubleEndedIterator for $quadrature_rule_nodes<'a> {
+            fn next_back(&mut self) -> Option<Self::Item> {
+                self.iter_map.next_back()
+            }
+        }
+
+        impl<'a> ::core::iter::ExactSizeIterator for $quadrature_rule_nodes<'a> {}
+        impl<'a> ::core::iter::FusedIterator for $quadrature_rule_nodes<'a> {}
+
+        // endregion: QuadratureRuleNodes
+
+        // region: QuadratureRuleWeights
+
+        /// An iterator over the weights of the quadrature rule.
+        #[derive(Debug, Clone)]
+        #[must_use = "iterators are lazy and do nothing unless consumed"]
+        pub struct $quadrature_rule_weights<'a> {
+            iter_map: ::std::iter::Map<
+                ::core::slice::Iter<'a, (Node, Weight)>,
+                fn(&'a (Node, Weight)) -> &'a Weight,
+            >,
+        }
+
+        impl<'a> $quadrature_rule_weights<'a> {
+            pub(super) fn new(
+                iter_map: ::std::iter::Map<
+                    ::core::slice::Iter<'a, (Node, Weight)>,
+                    fn(&'a (Node, Weight)) -> &'a Weight,
+                >,
+            ) -> Self {
+                Self { iter_map }
+            }
+        }
+
+        impl<'a> ::core::iter::Iterator for $quadrature_rule_weights<'a> {
+            type Item = &'a Weight;
+            fn next(&mut self) -> Option<Self::Item> {
+                self.iter_map.next()
+            }
+
+            #[inline]
+            fn size_hint(&self) -> (usize, Option<usize>) {
+                self.iter_map.size_hint()
+            }
+        }
+
+        impl<'a> ::core::iter::DoubleEndedIterator for $quadrature_rule_weights<'a> {
+            fn next_back(&mut self) -> Option<Self::Item> {
+                self.iter_map.next_back()
+            }
+        }
+
+        impl<'a> ::core::iter::ExactSizeIterator for $quadrature_rule_weights<'a> {}
+        impl<'a> ::core::iter::FusedIterator for $quadrature_rule_weights<'a> {}
+
+        // endregion: QuadratureRuleWeights
+
+        // region: QuadratureRuleIter
 
         /// An iterator over node-weight-pairs of the quadrature rule.
         ///
@@ -107,6 +198,7 @@ macro_rules! impl_iterators {
         }
 
         impl<'a> ::core::iter::Iterator for $quadrature_rule_iter<'a> {
+            /// Element `.0` is the node and element `.1` the corresponding weight.
             type Item = &'a (Node, Weight);
             fn next(&mut self) -> Option<Self::Item> {
                 self.node_weight_pairs.next()
@@ -119,6 +211,10 @@ macro_rules! impl_iterators {
             }
         }
 
+        // endregion: QuadratureRuleIter
+
+        // region: QuadratureRuleIntoIter
+
         /// An owning iterator over the node-weight-pairs of the quadrature rule.
         ///
         /// Created by the [`IntoIterator`] trait implementation of the quadrature rule struct.
@@ -129,6 +225,7 @@ macro_rules! impl_iterators {
         }
 
         impl ::core::iter::Iterator for $quadrature_rule_into_iter {
+            /// Element `.0` is the node and element `.1` the corresponding weight.
             type Item = (Node, Weight);
             fn next(&mut self) -> Option<Self::Item> {
                 self.node_weight_pairs.next()
@@ -170,55 +267,7 @@ macro_rules! impl_iterators {
                 $quadrature_rule_into_iter::new(self.node_weight_pairs.into_iter())
             }
         }
-    };
-}
 
-/// This macro defines a struct with the given name that contains a `Map<Iter<'a, (f64, f64)>,fn(&'a (f64, f64)) -> &'a f64,>`.
-/// It then implements the [`Iterator`], [`DoubleEndedIterator`], [`ExactSizeIterator`], and [`FusedIterator`]
-///  traits for it, and the convenience method `as_slice`.
-#[doc(hidden)]
-#[macro_export]
-macro_rules! slice_map_iter_impl {
-    ($slice_iter:ident) => {
-        #[derive(Debug, Clone)]
-        #[must_use = "iterators are lazy and do nothing unless consumed"]
-        pub struct $slice_iter<'a> {
-            iter_map: ::std::iter::Map<
-                ::core::slice::Iter<'a, (Node, Weight)>,
-                fn(&'a (Node, Weight)) -> &'a f64,
-            >,
-        }
-
-        impl<'a> $slice_iter<'a> {
-            pub(super) fn new(
-                iter_map: ::std::iter::Map<
-                    ::core::slice::Iter<'a, (Node, Weight)>,
-                    fn(&'a (Node, Weight)) -> &'a f64,
-                >,
-            ) -> Self {
-                Self { iter_map }
-            }
-        }
-
-        impl<'a> ::core::iter::Iterator for $slice_iter<'a> {
-            type Item = &'a f64;
-            fn next(&mut self) -> Option<Self::Item> {
-                self.iter_map.next()
-            }
-
-            #[inline]
-            fn size_hint(&self) -> (usize, Option<usize>) {
-                self.iter_map.size_hint()
-            }
-        }
-
-        impl<'a> ::core::iter::DoubleEndedIterator for $slice_iter<'a> {
-            fn next_back(&mut self) -> Option<Self::Item> {
-                self.iter_map.next_back()
-            }
-        }
-
-        impl<'a> ::core::iter::ExactSizeIterator for $slice_iter<'a> {}
-        impl<'a> ::core::iter::FusedIterator for $slice_iter<'a> {}
+        // endregion: QuadratureRuleIntoIter
     };
 }

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -231,6 +231,9 @@ macro_rules! impl_iterators {
             }
         }
 
+        impl<'a> ::core::iter::ExactSizeIterator for $quadrature_rule_iter<'a> {}
+        impl<'a> ::core::iter::FusedIterator for $quadrature_rule_iter<'a> {}
+
         // endregion: QuadratureRuleIter
 
         // region: QuadratureRuleIntoIter

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -63,7 +63,7 @@ macro_rules! impl_data_api {
 }
 
 /// This macro defines the iterators used by the functions defined in the macro `impl_data_api`.
-/// It takes in the names of the same structs as that macro, 
+/// It takes in the names of the same structs as that macro,
 /// plus the name of the iterator that should be returned by the [`IntoIterator`] implementation.
 /// These iterators can only be created in the module where the macro is called
 /// or the module above it (due to the `pub(super)` marker on the constructors).

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -68,6 +68,12 @@ macro_rules! impl_data_api {
             pub fn into_nodes_and_weights(self) -> (Vec<f64>, Vec<f64>) {
                 (self.nodes, self.weights)
             }
+
+            /// Returns the degree of the quadrature rule.
+            #[inline]
+            pub fn degree(&self) -> usize {
+                self.nodes.len()
+            }
         }
 
         slice_iter_impl! {$quadrature_rule_nodes}

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -179,9 +179,7 @@ macro_rules! impl_iterators {
             pub(super) fn new(node_weight_pairs: ::core::slice::Iter<'a, (Node, Weight)>) -> Self {
                 Self(node_weight_pairs)
             }
-        }
 
-        impl<'a> $quadrature_rule_iter<'a> {
             /// Views the underlying data as a subslice of the original data.
             ///
             /// See [`core::slice::Iter::as_slice`] for more information.

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -81,7 +81,7 @@ macro_rules! impl_data_api {
         ///
         /// Created by the `iter` function on the quadrature rule.
         #[derive(Debug, Clone, Copy, PartialEq)]
-        #[must_use = "iterators do nothing unless consumed"]
+        #[must_use = "iterators are lazy and do nothing unless consumed"]
         pub struct $quadrature_rule_iter<'a> {
             node_iter: $quadrature_rule_nodes<'a>,
             weight_iter: $quadrature_rule_weights<'a>,
@@ -110,7 +110,7 @@ macro_rules! impl_data_api {
         ///
         /// Created by the [`IntoIterator`] trait implementation of the quadrature rule struct.
         #[derive(Debug, Clone, PartialEq)]
-        #[must_use = "iterators do nothing unless consumed"]
+        #[must_use = "iterators are lazy and do nothing unless consumed"]
         pub struct $quadrature_rule_into_iter {
             nodes: Vec<f64>,
             weights: Vec<f64>,
@@ -194,7 +194,7 @@ macro_rules! impl_data_api {
 macro_rules! slice_iter_impl {
     ($slice_iter:ident) => {
         #[derive(Debug, Clone, Copy, PartialEq)]
-        #[must_use = "iterators do nothing unless consumed"]
+        #[must_use = "iterators are lazy and do nothing unless consumed"]
         pub struct $slice_iter<'a> {
             slice: &'a [f64],
             index: usize,

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -1,8 +1,3 @@
-/// A node in a quadrature rule.
-pub type Node = f64;
-/// A weight in a quadrature rule.
-pub type Weight = f64;
-
 /// This macro implements the data access API for the given quadrature rule struct.
 /// It takes in the name of the quadrature rule as well as the names of the iterators
 /// over its nodes, weights, both, and IntoIterator implementation.

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -102,6 +102,7 @@ macro_rules! impl_iterators {
         );
 
         impl<'a> $quadrature_rule_nodes<'a> {
+            #[inline]
             pub(super) fn new(
                 iter_map: ::std::iter::Map<
                     ::core::slice::Iter<'a, ($crate::Node, $crate::Weight)>,
@@ -153,6 +154,7 @@ macro_rules! impl_iterators {
         );
 
         impl<'a> $quadrature_rule_weights<'a> {
+            #[inline]
             pub(super) fn new(
                 iter_map: ::std::iter::Map<
                     ::core::slice::Iter<'a, ($crate::Node, $crate::Weight)>,
@@ -203,6 +205,7 @@ macro_rules! impl_iterators {
         );
 
         impl<'a> $quadrature_rule_iter<'a> {
+            #[inline]
             pub(super) fn new(
                 node_weight_pairs: ::core::slice::Iter<'a, ($crate::Node, $crate::Weight)>,
             ) -> Self {
@@ -212,6 +215,7 @@ macro_rules! impl_iterators {
             /// Views the underlying data as a subslice of the original data.
             ///
             /// See [`core::slice::Iter::as_slice`] for more information.
+            #[inline]
             pub fn as_slice(&self) -> &'a [($crate::Node, $crate::Weight)] {
                 self.0.as_slice()
             }
@@ -282,6 +286,7 @@ macro_rules! impl_iterators {
         impl ::core::iter::FusedIterator for $quadrature_rule_into_iter {}
 
         impl $quadrature_rule_into_iter {
+            #[inline]
             pub(super) fn new(
                 node_weight_pairs: ::std::vec::IntoIter<($crate::Node, $crate::Weight)>,
             ) -> Self {
@@ -309,6 +314,7 @@ macro_rules! impl_iterators {
         impl ::core::iter::IntoIterator for $quadrature_rule {
             type IntoIter = $quadrature_rule_into_iter;
             type Item = ($crate::Node, $crate::Weight);
+            #[inline]
             fn into_iter(self) -> Self::IntoIter {
                 $quadrature_rule_into_iter::new(self.node_weight_pairs.into_iter())
             }

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -1,6 +1,6 @@
 //! This module contains two macros: [`impl_data_api!`] and [`impl_iterators!`].
 //! The first takes in the name of a quadrature rule struct that has a field named `node_weight_pairs`
-//! of the type `Vec<(f64, f64)>`. It also needs the names that it should give the various structs
+//! of the type `Vec<(Node, Weight)>`. It also needs the names that it should give the various structs
 //! that iterate over that data. It should be called in the module that defines the quadrature rule struct.
 //! The second macro defines the iterators that the first returns. It should be called somewhere it makes sense
 //! for the iterators to be defined, e.g. a sub-module.

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -1,3 +1,15 @@
+//! This module contains two macros: [`impl_data_api!`] and [`impl_iterators!`].
+//! The first takes in the name of a quadrature rule struct that has a field named `node_weight_pairs`
+//! of the type `Vec<(f64, f64)>`. It also needs the names that it should give the various structs
+//! that iterate over that data. It should be called in the module that defines the quadrature rule struct.
+//! The second macro defines the iterators that the first returns. It should be called somewhere it makes sense
+//! for the iterators to be defined, e.g. a sub-module.
+//!
+
+// The code in the macros uses fully qualified paths for every type, so it is quite verbose.
+// That is, instead of `usize` it uses `::core::primitive::usize` and so on. This makes it so that
+// the called of the macro doesn't have to import anything into the module in order for the macro to compile.
+
 /// This macro implements the data access API for the given quadrature rule struct.
 /// It takes in the name of the quadrature rule struct as well as the names of the iterators
 /// over its nodes, weights, and both.

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -49,13 +49,13 @@ macro_rules! impl_data_api {
             /// computation or cloning.
             #[inline]
             #[must_use = "`self` will be dropped if the result is not used"]
-            pub fn into_node_weight_pairs(self) -> Vec<(Node, Weight)> {
+            pub fn into_node_weight_pairs(self) -> ::std::vec::Vec<(Node, Weight)> {
                 self.node_weight_pairs
             }
 
             /// Returns the degree of the quadrature rule.
             #[inline]
-            pub fn degree(&self) -> usize {
+            pub fn degree(&self) -> ::core::primitive::usize {
                 self.node_weight_pairs.len()
             }
         }
@@ -79,20 +79,20 @@ macro_rules! impl_iterators {
         // region: QuadratureRuleNodes
 
         /// An iterator over the nodes of the quadrature rule.
-        #[derive(Debug, Clone)]
+        #[derive(::core::fmt::Debug, ::core::clone::Clone)]
         #[must_use = "iterators are lazy and do nothing unless consumed"]
         pub struct $quadrature_rule_nodes<'a>(
             ::std::iter::Map<
-                ::core::slice::Iter<'a, (Node, Weight)>,
-                fn(&'a (Node, Weight)) -> &'a Node,
+                ::core::slice::Iter<'a, ($crate::Node, $crate::Weight)>,
+                fn(&'a ($crate::Node, $crate::Weight)) -> &'a $crate::Node,
             >,
         );
 
         impl<'a> $quadrature_rule_nodes<'a> {
             pub(super) fn new(
                 iter_map: ::std::iter::Map<
-                    ::core::slice::Iter<'a, (Node, Weight)>,
-                    fn(&'a (Node, Weight)) -> &'a Node,
+                    ::core::slice::Iter<'a, ($crate::Node, $crate::Weight)>,
+                    fn(&'a ($crate::Node, $crate::Weight)) -> &'a $crate::Node,
                 >,
             ) -> Self {
                 Self(iter_map)
@@ -100,19 +100,24 @@ macro_rules! impl_iterators {
         }
 
         impl<'a> ::core::iter::Iterator for $quadrature_rule_nodes<'a> {
-            type Item = &'a Node;
-            fn next(&mut self) -> Option<Self::Item> {
+            type Item = &'a $crate::Node;
+            fn next(&mut self) -> ::core::option::Option<Self::Item> {
                 self.0.next()
             }
 
             #[inline]
-            fn size_hint(&self) -> (usize, Option<usize>) {
+            fn size_hint(
+                &self,
+            ) -> (
+                ::core::primitive::usize,
+                ::core::option::Option<::core::primitive::usize>,
+            ) {
                 self.0.size_hint()
             }
         }
 
         impl<'a> ::core::iter::DoubleEndedIterator for $quadrature_rule_nodes<'a> {
-            fn next_back(&mut self) -> Option<Self::Item> {
+            fn next_back(&mut self) -> ::core::option::Option<Self::Item> {
                 self.0.next_back()
             }
         }
@@ -125,20 +130,20 @@ macro_rules! impl_iterators {
         // region: QuadratureRuleWeights
 
         /// An iterator over the weights of the quadrature rule.
-        #[derive(Debug, Clone)]
+        #[derive(::core::fmt::Debug, ::core::clone::Clone)]
         #[must_use = "iterators are lazy and do nothing unless consumed"]
         pub struct $quadrature_rule_weights<'a>(
             ::std::iter::Map<
-                ::core::slice::Iter<'a, (Node, Weight)>,
-                fn(&'a (Node, Weight)) -> &'a Weight,
+                ::core::slice::Iter<'a, ($crate::Node, $crate::Weight)>,
+                fn(&'a ($crate::Node, $crate::Weight)) -> &'a $crate::Weight,
             >,
         );
 
         impl<'a> $quadrature_rule_weights<'a> {
             pub(super) fn new(
                 iter_map: ::std::iter::Map<
-                    ::core::slice::Iter<'a, (Node, Weight)>,
-                    fn(&'a (Node, Weight)) -> &'a Weight,
+                    ::core::slice::Iter<'a, ($crate::Node, $crate::Weight)>,
+                    fn(&'a ($crate::Node, $crate::Weight)) -> &'a $crate::Weight,
                 >,
             ) -> Self {
                 Self(iter_map)
@@ -146,19 +151,24 @@ macro_rules! impl_iterators {
         }
 
         impl<'a> ::core::iter::Iterator for $quadrature_rule_weights<'a> {
-            type Item = &'a Weight;
-            fn next(&mut self) -> Option<Self::Item> {
+            type Item = &'a $crate::Weight;
+            fn next(&mut self) -> ::core::option::Option<Self::Item> {
                 self.0.next()
             }
 
             #[inline]
-            fn size_hint(&self) -> (usize, Option<usize>) {
+            fn size_hint(
+                &self,
+            ) -> (
+                ::core::primitive::usize,
+                ::core::option::Option<::core::primitive::usize>,
+            ) {
                 self.0.size_hint()
             }
         }
 
         impl<'a> ::core::iter::DoubleEndedIterator for $quadrature_rule_weights<'a> {
-            fn next_back(&mut self) -> Option<Self::Item> {
+            fn next_back(&mut self) -> ::core::option::Option<Self::Item> {
                 self.0.next_back()
             }
         }
@@ -173,33 +183,37 @@ macro_rules! impl_iterators {
         /// An iterator over node-weight-pairs of the quadrature rule.
         ///
         /// Created by the `iter` function on the quadrature rule struct.
-        #[derive(Debug, Clone)]
+        #[derive(::core::fmt::Debug, ::core::clone::Clone)]
         #[must_use = "iterators are lazy and do nothing unless consumed"]
-        pub struct $quadrature_rule_iter<'a>(::core::slice::Iter<'a, (Node, Weight)>);
+        pub struct $quadrature_rule_iter<'a>(
+            ::core::slice::Iter<'a, ($crate::Node, $crate::Weight)>,
+        );
 
         impl<'a> $quadrature_rule_iter<'a> {
-            pub(super) fn new(node_weight_pairs: ::core::slice::Iter<'a, (Node, Weight)>) -> Self {
+            pub(super) fn new(
+                node_weight_pairs: ::core::slice::Iter<'a, ($crate::Node, $crate::Weight)>,
+            ) -> Self {
                 Self(node_weight_pairs)
             }
 
             /// Views the underlying data as a subslice of the original data.
             ///
             /// See [`core::slice::Iter::as_slice`] for more information.
-            pub fn as_slice(&self) -> &'a [(Node, Weight)] {
+            pub fn as_slice(&self) -> &'a [($crate::Node, $crate::Weight)] {
                 self.0.as_slice()
             }
         }
 
         impl<'a> ::core::iter::Iterator for $quadrature_rule_iter<'a> {
             /// Element `.0` is the node and element `.1` the corresponding weight.
-            type Item = &'a (Node, Weight);
-            fn next(&mut self) -> Option<Self::Item> {
+            type Item = &'a ($crate::Node, $crate::Weight);
+            fn next(&mut self) -> ::core::option::Option<Self::Item> {
                 self.0.next()
             }
         }
 
         impl<'a> ::core::iter::DoubleEndedIterator for $quadrature_rule_iter<'a> {
-            fn next_back(&mut self) -> Option<Self::Item> {
+            fn next_back(&mut self) -> ::core::option::Option<Self::Item> {
                 self.0.next_back()
             }
         }
@@ -211,25 +225,30 @@ macro_rules! impl_iterators {
         /// An owning iterator over the node-weight-pairs of the quadrature rule.
         ///
         /// Created by the [`IntoIterator`] trait implementation of the quadrature rule struct.
-        #[derive(Debug, Clone)]
+        #[derive(::core::fmt::Debug, ::core::clone::Clone)]
         #[must_use = "iterators are lazy and do nothing unless consumed"]
-        pub struct $quadrature_rule_into_iter(::std::vec::IntoIter<(Node, Weight)>);
+        pub struct $quadrature_rule_into_iter(::std::vec::IntoIter<($crate::Node, $crate::Weight)>);
 
         impl ::core::iter::Iterator for $quadrature_rule_into_iter {
             /// Element `.0` is the node and element `.1` the corresponding weight.
-            type Item = (Node, Weight);
-            fn next(&mut self) -> Option<Self::Item> {
+            type Item = ($crate::Node, $crate::Weight);
+            fn next(&mut self) -> ::core::option::Option<Self::Item> {
                 self.0.next()
             }
 
             #[inline]
-            fn size_hint(&self) -> (usize, Option<usize>) {
+            fn size_hint(
+                &self,
+            ) -> (
+                ::core::primitive::usize,
+                ::core::option::Option<::core::primitive::usize>,
+            ) {
                 self.0.size_hint()
             }
         }
 
         impl ::core::iter::DoubleEndedIterator for $quadrature_rule_into_iter {
-            fn next_back(&mut self) -> Option<Self::Item> {
+            fn next_back(&mut self) -> ::core::option::Option<Self::Item> {
                 self.0.next_back()
             }
         }
@@ -238,7 +257,9 @@ macro_rules! impl_iterators {
         impl ::core::iter::FusedIterator for $quadrature_rule_into_iter {}
 
         impl $quadrature_rule_into_iter {
-            pub(super) fn new(node_weight_pairs: ::std::vec::IntoIter<(Node, Weight)>) -> Self {
+            pub(super) fn new(
+                node_weight_pairs: ::std::vec::IntoIter<($crate::Node, $crate::Weight)>,
+            ) -> Self {
                 Self(node_weight_pairs)
             }
 
@@ -246,14 +267,14 @@ macro_rules! impl_iterators {
             ///
             /// See [`core::slice::Iter::as_slice`] for more information.
             #[inline]
-            pub fn as_slice(&self) -> &[(Node, Weight)] {
+            pub fn as_slice(&self) -> &[($crate::Node, $crate::Weight)] {
                 self.0.as_slice()
             }
         }
 
         impl ::core::iter::IntoIterator for $quadrature_rule {
             type IntoIter = $quadrature_rule_into_iter;
-            type Item = (Node, Weight);
+            type Item = ($crate::Node, $crate::Weight);
             fn into_iter(self) -> Self::IntoIter {
                 $quadrature_rule_into_iter::new(self.node_weight_pairs.into_iter())
             }

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -2,8 +2,6 @@
 pub type Node = f64;
 /// A weight in a quadrature rule.
 pub type Weight = f64;
-/// A pair of a node and its corresponding weight from a quadrature rule.
-pub type NodeWeightPair = (Node, Weight);
 
 /// This macro implements the data access API for the given quadrature rule struct.
 /// It takes in the name of the quadrature rule as well as the names of the iterators

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -4,7 +4,6 @@
 //! that iterate over that data. It should be called in the module that defines the quadrature rule struct.
 //! The second macro defines the iterators that the first returns. It should be called somewhere it makes sense
 //! for the iterators to be defined, e.g. a sub-module.
-//!
 
 // The code in the macros uses fully qualified paths for every type, so it is quite verbose.
 // That is, instead of `usize` it uses `::core::primitive::usize` and so on. This makes it so that

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -181,10 +181,9 @@ macro_rules! impl_data_api {
     };
 }
 
-/// This macro defines a struct with the given name that contains a slice and two
-/// indices, one from the front and one from the back.
-/// It then implements the [`Iterator`] trait for it, and the convenience method
-/// `as_slice`. Kind of a rename of [`core::slice::Iter`].
+/// This macro defines a struct with the given name that contains a [`core::slice::Iter`].
+/// It then implements the [`Iterator`], [`DoubleEndedIterator`], [`ExactSizeIterator`], and [`FusedIterator`]
+///  traits for it, and the convenience method `as_slice`.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! slice_iter_impl {

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -1,3 +1,10 @@
+/// A node in a quadrature rule.
+pub type Node = f64;
+/// A weight in a quadrature rule.
+pub type Weight = f64;
+/// A pair of a node and its corresponding weight from a quadrature rule.
+pub type NodeWeightPair = (Node, Weight);
+
 /// This macro implements the data access API for the given quadrature rule struct.
 /// It takes in the name of the quadrature rule as well as the names of the iterators
 /// over its nodes, weights, both, and IntoIterator implementation.
@@ -36,10 +43,10 @@ macro_rules! impl_data_api {
             }
 
             /// Returns a slice of the node-weight-pairs of the quadrature rule.
-            /// 
+            ///
             /// Element `.0` of the tuples is the node and element `.1` its corresponding weight.
             #[inline]
-            pub fn as_node_weight_pairs(&self) -> &[(f64, f64)] {
+            pub fn as_node_weight_pairs(&self) -> &[(Node, Weight)] {
                 &self.node_weight_pairs
             }
 
@@ -49,7 +56,7 @@ macro_rules! impl_data_api {
             /// computation or cloning.
             #[inline]
             #[must_use = "`self` will be dropped if the result is not used"]
-            pub fn into_node_weight_pairs(self) -> Vec<(f64, f64)> {
+            pub fn into_node_weight_pairs(self) -> Vec<(Node, Weight)> {
                 self.node_weight_pairs
             }
 
@@ -83,11 +90,11 @@ macro_rules! impl_iterators {
         #[derive(Debug, Clone)]
         #[must_use = "iterators are lazy and do nothing unless consumed"]
         pub struct $quadrature_rule_iter<'a> {
-            node_weight_pairs: ::core::slice::Iter<'a, (f64, f64)>,
+            node_weight_pairs: ::core::slice::Iter<'a, (Node, Weight)>,
         }
 
         impl<'a> $quadrature_rule_iter<'a> {
-            pub(super) fn new(node_weight_pairs: ::core::slice::Iter<'a, (f64, f64)>) -> Self {
+            pub(super) fn new(node_weight_pairs: ::core::slice::Iter<'a, (Node, Weight)>) -> Self {
                 Self { node_weight_pairs }
             }
         }
@@ -96,13 +103,13 @@ macro_rules! impl_iterators {
             /// Views the underlying data as a subslice of the original data.
             ///
             /// See [`core::slice::Iter::as_slice`] for more information.
-            pub fn as_slice(&self) -> &'a [(f64, f64)] {
+            pub fn as_slice(&self) -> &'a [(Node, Weight)] {
                 self.node_weight_pairs.as_slice()
             }
         }
 
         impl<'a> ::core::iter::Iterator for $quadrature_rule_iter<'a> {
-            type Item = &'a (f64, f64);
+            type Item = &'a (Node, Weight);
             fn next(&mut self) -> Option<Self::Item> {
                 self.node_weight_pairs.next()
             }
@@ -120,11 +127,11 @@ macro_rules! impl_iterators {
         #[derive(Debug, Clone)]
         #[must_use = "iterators are lazy and do nothing unless consumed"]
         pub struct $quadrature_rule_into_iter {
-            node_weight_pairs: ::std::vec::IntoIter<(f64, f64)>,
+            node_weight_pairs: ::std::vec::IntoIter<(Node, Weight)>,
         }
 
         impl ::core::iter::Iterator for $quadrature_rule_into_iter {
-            type Item = (f64, f64);
+            type Item = (Node, Weight);
             fn next(&mut self) -> Option<Self::Item> {
                 self.node_weight_pairs.next()
             }
@@ -145,7 +152,7 @@ macro_rules! impl_iterators {
         impl ::core::iter::FusedIterator for $quadrature_rule_into_iter {}
 
         impl $quadrature_rule_into_iter {
-            pub(super) fn new(node_weight_pairs: ::std::vec::IntoIter<(f64, f64)>) -> Self {
+            pub(super) fn new(node_weight_pairs: ::std::vec::IntoIter<(Node, Weight)>) -> Self {
                 Self { node_weight_pairs }
             }
 
@@ -153,14 +160,14 @@ macro_rules! impl_iterators {
             ///
             /// See [`core::slice::Iter::as_slice`] for more information.
             #[inline]
-            pub fn as_slice(&self) -> &[(f64, f64)] {
+            pub fn as_slice(&self) -> &[(Node, Weight)] {
                 self.node_weight_pairs.as_slice()
             }
         }
 
         impl ::core::iter::IntoIterator for $quadrature_rule {
             type IntoIter = $quadrature_rule_into_iter;
-            type Item = (f64, f64);
+            type Item = (Node, Weight);
             fn into_iter(self) -> Self::IntoIter {
                 $quadrature_rule_into_iter::new(self.node_weight_pairs.into_iter())
             }
@@ -179,16 +186,16 @@ macro_rules! slice_map_iter_impl {
         #[must_use = "iterators are lazy and do nothing unless consumed"]
         pub struct $slice_iter<'a> {
             iter_map: ::std::iter::Map<
-                ::core::slice::Iter<'a, (f64, f64)>,
-                fn(&'a (f64, f64)) -> &'a f64,
+                ::core::slice::Iter<'a, (Node, Weight)>,
+                fn(&'a (Node, Weight)) -> &'a f64,
             >,
         }
 
         impl<'a> $slice_iter<'a> {
             pub(super) fn new(
                 iter_map: ::std::iter::Map<
-                    ::core::slice::Iter<'a, (f64, f64)>,
-                    fn(&'a (f64, f64)) -> &'a f64,
+                    ::core::slice::Iter<'a, (Node, Weight)>,
+                    fn(&'a (Node, Weight)) -> &'a f64,
                 >,
             ) -> Self {
                 Self { iter_map }

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -36,6 +36,8 @@ macro_rules! impl_data_api {
             }
 
             /// Returns a slice of the node-weight-pairs of the quadrature rule.
+            /// 
+            /// Element `.0` of the tuples is the node and element `.1` its corresponding weight.
             #[inline]
             pub fn as_node_weight_pairs(&self) -> &[(f64, f64)] {
                 &self.node_weight_pairs

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -1,6 +1,6 @@
 /// This macro implements the data access API for the given quadrature rule struct.
 /// It takes in the name of the quadrature rule as well as the names of the iterators
-/// over its nodes, weights, both, and IntoIterator implementation.
+/// over its nodes, weights, and both. Also defined the iterator used by the IntoIterator implementation.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! impl_data_api {

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -24,9 +24,7 @@ macro_rules! impl_data_api {
             #[inline]
             pub fn nodes(&self) -> $quadrature_rule_nodes<'_> {
                 $quadrature_rule_nodes {
-                    slice: &self.nodes,
-                    index: 0,
-                    back_index: self.nodes.len(),
+                    iter: self.nodes.iter(),
                 }
             }
 
@@ -40,9 +38,7 @@ macro_rules! impl_data_api {
             #[inline]
             pub fn weights(&self) -> $quadrature_rule_weights<'_> {
                 $quadrature_rule_weights {
-                    slice: &self.weights,
-                    index: 0,
-                    back_index: self.weights.len(),
+                    iter: self.weights.iter(),
                 }
             }
 
@@ -80,7 +76,7 @@ macro_rules! impl_data_api {
         /// An iterator over the quadrature rule's nodes and weights.
         ///
         /// Created by the `iter` function on the quadrature rule.
-        #[derive(Debug, Clone, Copy, PartialEq)]
+        #[derive(Debug, Clone)]
         #[must_use = "iterators are lazy and do nothing unless consumed"]
         pub struct $quadrature_rule_iter<'a> {
             node_iter: $quadrature_rule_nodes<'a>,
@@ -193,42 +189,27 @@ macro_rules! impl_data_api {
 #[macro_export]
 macro_rules! slice_iter_impl {
     ($slice_iter:ident) => {
-        #[derive(Debug, Clone, Copy, PartialEq)]
+        #[derive(Debug, Clone)]
         #[must_use = "iterators are lazy and do nothing unless consumed"]
         pub struct $slice_iter<'a> {
-            slice: &'a [f64],
-            index: usize,
-            back_index: usize,
+            iter: ::core::slice::Iter<'a, f64>,
         }
 
         impl<'a> ::core::iter::Iterator for $slice_iter<'a> {
             type Item = &'a f64;
             fn next(&mut self) -> Option<Self::Item> {
-                if self.index < self.back_index {
-                    let out = Some(&self.slice[self.index]);
-                    self.index += 1;
-                    out
-                } else {
-                    None
-                }
+                self.iter.next()
             }
 
             #[inline]
             fn size_hint(&self) -> (usize, Option<usize>) {
-                let len = self.back_index - self.index;
-                (len, Some(len))
+                self.iter.size_hint()
             }
         }
 
         impl<'a> ::core::iter::DoubleEndedIterator for $slice_iter<'a> {
             fn next_back(&mut self) -> Option<Self::Item> {
-                if self.index < self.back_index {
-                    let out = Some(&self.slice[self.back_index]);
-                    self.back_index -= 1;
-                    out
-                } else {
-                    None
-                }
+                self.iter.next_back()
             }
         }
 
@@ -239,7 +220,7 @@ macro_rules! slice_iter_impl {
             /// Returns a view of the underlying data as a slice.
             #[inline]
             pub fn as_slice(&self) -> &'a [f64] {
-                &self.slice[self.index..self.back_index]
+                self.iter.as_slice()
             }
         }
     };

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -1,6 +1,6 @@
 /// This macro implements the data access API for the given quadrature rule struct.
 /// It takes in the name of the quadrature rule as well as the names of the iterators
-/// over its nodes, weights, and both. Also defined the iterator used by the IntoIterator implementation.
+/// over its nodes, weights, and both. Also defines the iterator used by the IntoIterator implementation.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! impl_data_api {

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -64,6 +64,8 @@ macro_rules! impl_data_api {
 
 /// This macro defines the iterators used by the functions defined in the macro `impl_data_api`.
 /// It takes in the names of the same structs as that macro.
+/// These iterators can only be created in the module where the macro is called
+/// or the module above it (due to the `pub(super)`).
 #[doc(hidden)]
 #[macro_export]
 macro_rules! impl_iterators {

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -297,6 +297,15 @@ macro_rules! impl_iterators {
             }
         }
 
+        impl<'a> ::core::convert::AsRef<[($crate::Node, $crate::Weight)]>
+            for $quadrature_rule_into_iter
+        {
+            #[inline]
+            fn as_ref(&self) -> &[($crate::Node, $crate::Weight)] {
+                self.0.as_ref()
+            }
+        }
+
         impl ::core::iter::IntoIterator for $quadrature_rule {
             type IntoIter = $quadrature_rule_into_iter;
             type Item = ($crate::Node, $crate::Weight);

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -61,7 +61,8 @@ macro_rules! impl_data_api {
 }
 
 /// This macro defines the iterators used by the functions defined in the macro `impl_data_api`.
-/// It takes in the names of the same structs as that macro.
+/// It takes in the names of the same structs as that macro, plus the name of the iterator returned
+/// by the [`IntoIterator`] implementation.
 /// These iterators can only be created in the module where the macro is called
 /// or the module above it (due to the `pub(super)`).
 #[doc(hidden)]

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -36,8 +36,6 @@ macro_rules! impl_data_api {
             }
 
             /// Returns a slice of the node-weight-pairs of the quadrature rule.
-            ///
-            /// Element `.0` of the tuples is the node and element `.1` its corresponding weight.
             #[inline]
             pub fn as_node_weight_pairs(&self) -> &[(Node, Weight)] {
                 &self.node_weight_pairs

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -234,6 +234,15 @@ macro_rules! impl_iterators {
         impl<'a> ::core::iter::ExactSizeIterator for $quadrature_rule_iter<'a> {}
         impl<'a> ::core::iter::FusedIterator for $quadrature_rule_iter<'a> {}
 
+        impl<'a> ::core::convert::AsRef<[($crate::Node, $crate::Weight)]>
+            for $quadrature_rule_iter<'a>
+        {
+            #[inline]
+            fn as_ref(&self) -> &[($crate::Node, $crate::Weight)] {
+                self.0.as_ref()
+            }
+        }
+
         // endregion: QuadratureRuleIter
 
         // region: QuadratureRuleIntoIter

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -43,8 +43,6 @@ macro_rules! impl_data_api {
 
             /// Converts the quadrature rule into a vector of node-weight-pairs.
             ///
-            /// Element `.0` is the nodes of the rule and element `.1` is the weights.
-            ///
             /// This function just returns the underlying data and does no
             /// computation or cloning.
             #[inline]
@@ -74,8 +72,8 @@ macro_rules! impl_iterators {
         $quadrature_rule_iter:ident,
         $quadrature_rule_into_iter:ident
     ) => {
-        slice_iter_map_impl! {$quadrature_rule_nodes}
-        slice_iter_map_impl! {$quadrature_rule_weights}
+        slice_map_iter_impl! {$quadrature_rule_nodes}
+        slice_map_iter_impl! {$quadrature_rule_weights}
 
         /// An iterator over node-weight-pairs of the quadrature rule.
         ///
@@ -93,7 +91,9 @@ macro_rules! impl_iterators {
         }
 
         impl<'a> $quadrature_rule_iter<'a> {
-            /// Returns a view of the underlying data.
+            /// Views the underlying data as a subslice of the original data.
+            ///
+            /// See [`core::slice::Iter::as_slice`] for more information.
             pub fn as_slice(&self) -> &'a [(f64, f64)] {
                 self.node_weight_pairs.as_slice()
             }
@@ -112,7 +112,7 @@ macro_rules! impl_iterators {
             }
         }
 
-        /// An owning iterator over the nodes and weights of the quadrature rule.
+        /// An owning iterator over the node-weight-pairs of the quadrature rule.
         ///
         /// Created by the [`IntoIterator`] trait implementation of the quadrature rule struct.
         #[derive(Debug, Clone)]
@@ -147,9 +147,9 @@ macro_rules! impl_iterators {
                 Self { node_weight_pairs }
             }
 
-            /// Returns a view into the underlying data as a slice of tuples.
+            /// Views the underlying data as a subslice of the original data.
             ///
-            /// Element `.0` of the tuples is the node and element `.1` its corresponding weight.
+            /// See [`core::slice::Iter::as_slice`] for more information.
             #[inline]
             pub fn as_slice(&self) -> &[(f64, f64)] {
                 self.node_weight_pairs.as_slice()
@@ -166,12 +166,12 @@ macro_rules! impl_iterators {
     };
 }
 
-/// This macro defines a struct with the given name that contains a [`core::slice::Iter`].
+/// This macro defines a struct with the given name that contains a `Map<Iter<'a, (f64, f64)>,fn(&'a (f64, f64)) -> &'a f64,>`.
 /// It then implements the [`Iterator`], [`DoubleEndedIterator`], [`ExactSizeIterator`], and [`FusedIterator`]
 ///  traits for it, and the convenience method `as_slice`.
 #[doc(hidden)]
 #[macro_export]
-macro_rules! slice_iter_map_impl {
+macro_rules! slice_map_iter_impl {
     ($slice_iter:ident) => {
         #[derive(Debug, Clone)]
         #[must_use = "iterators are lazy and do nothing unless consumed"]

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -238,7 +238,7 @@ macro_rules! slice_iter_impl {
         impl<'a> $slice_iter<'a> {
             /// Returns a view of the underlying data as a slice.
             #[inline]
-            pub fn as_slice(&self) -> &[f64] {
+            pub fn as_slice(&self) -> &'a [f64] {
                 &self.slice[self.index..self.back_index]
             }
         }

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -62,10 +62,18 @@ macro_rules! impl_data_api {
     };
 }
 
+/// This macro defines the iterators used by the functions defined in the macro `impl_data_api`.
+/// It takes in the names of the same structs as that macro.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! impl_iterators {
-    ($quadrature_rule:ident, $quadrature_rule_nodes:ident, $quadrature_rule_weights:ident, $quadrature_rule_iter:ident, $quadrature_rule_into_iter:ident) => {
+    (
+        $quadrature_rule:ident,
+        $quadrature_rule_nodes:ident,
+        $quadrature_rule_weights:ident,
+        $quadrature_rule_iter:ident,
+        $quadrature_rule_into_iter:ident
+    ) => {
         slice_iter_map_impl! {$quadrature_rule_nodes}
         slice_iter_map_impl! {$quadrature_rule_weights}
 

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -79,12 +79,12 @@ macro_rules! impl_iterators {
         /// An iterator over the nodes of the quadrature rule.
         #[derive(Debug, Clone)]
         #[must_use = "iterators are lazy and do nothing unless consumed"]
-        pub struct $quadrature_rule_nodes<'a> {
-            iter_map: ::std::iter::Map<
+        pub struct $quadrature_rule_nodes<'a>(
+            ::std::iter::Map<
                 ::core::slice::Iter<'a, (Node, Weight)>,
                 fn(&'a (Node, Weight)) -> &'a Node,
             >,
-        }
+        );
 
         impl<'a> $quadrature_rule_nodes<'a> {
             pub(super) fn new(
@@ -93,25 +93,25 @@ macro_rules! impl_iterators {
                     fn(&'a (Node, Weight)) -> &'a Node,
                 >,
             ) -> Self {
-                Self { iter_map }
+                Self(iter_map)
             }
         }
 
         impl<'a> ::core::iter::Iterator for $quadrature_rule_nodes<'a> {
             type Item = &'a Node;
             fn next(&mut self) -> Option<Self::Item> {
-                self.iter_map.next()
+                self.0.next()
             }
 
             #[inline]
             fn size_hint(&self) -> (usize, Option<usize>) {
-                self.iter_map.size_hint()
+                self.0.size_hint()
             }
         }
 
         impl<'a> ::core::iter::DoubleEndedIterator for $quadrature_rule_nodes<'a> {
             fn next_back(&mut self) -> Option<Self::Item> {
-                self.iter_map.next_back()
+                self.0.next_back()
             }
         }
 
@@ -125,12 +125,12 @@ macro_rules! impl_iterators {
         /// An iterator over the weights of the quadrature rule.
         #[derive(Debug, Clone)]
         #[must_use = "iterators are lazy and do nothing unless consumed"]
-        pub struct $quadrature_rule_weights<'a> {
-            iter_map: ::std::iter::Map<
+        pub struct $quadrature_rule_weights<'a>(
+            ::std::iter::Map<
                 ::core::slice::Iter<'a, (Node, Weight)>,
                 fn(&'a (Node, Weight)) -> &'a Weight,
             >,
-        }
+        );
 
         impl<'a> $quadrature_rule_weights<'a> {
             pub(super) fn new(
@@ -139,25 +139,25 @@ macro_rules! impl_iterators {
                     fn(&'a (Node, Weight)) -> &'a Weight,
                 >,
             ) -> Self {
-                Self { iter_map }
+                Self(iter_map)
             }
         }
 
         impl<'a> ::core::iter::Iterator for $quadrature_rule_weights<'a> {
             type Item = &'a Weight;
             fn next(&mut self) -> Option<Self::Item> {
-                self.iter_map.next()
+                self.0.next()
             }
 
             #[inline]
             fn size_hint(&self) -> (usize, Option<usize>) {
-                self.iter_map.size_hint()
+                self.0.size_hint()
             }
         }
 
         impl<'a> ::core::iter::DoubleEndedIterator for $quadrature_rule_weights<'a> {
             fn next_back(&mut self) -> Option<Self::Item> {
-                self.iter_map.next_back()
+                self.0.next_back()
             }
         }
 
@@ -173,13 +173,11 @@ macro_rules! impl_iterators {
         /// Created by the `iter` function on the quadrature rule struct.
         #[derive(Debug, Clone)]
         #[must_use = "iterators are lazy and do nothing unless consumed"]
-        pub struct $quadrature_rule_iter<'a> {
-            node_weight_pairs: ::core::slice::Iter<'a, (Node, Weight)>,
-        }
+        pub struct $quadrature_rule_iter<'a>(::core::slice::Iter<'a, (Node, Weight)>);
 
         impl<'a> $quadrature_rule_iter<'a> {
             pub(super) fn new(node_weight_pairs: ::core::slice::Iter<'a, (Node, Weight)>) -> Self {
-                Self { node_weight_pairs }
+                Self(node_weight_pairs)
             }
         }
 
@@ -188,7 +186,7 @@ macro_rules! impl_iterators {
             ///
             /// See [`core::slice::Iter::as_slice`] for more information.
             pub fn as_slice(&self) -> &'a [(Node, Weight)] {
-                self.node_weight_pairs.as_slice()
+                self.0.as_slice()
             }
         }
 
@@ -196,13 +194,13 @@ macro_rules! impl_iterators {
             /// Element `.0` is the node and element `.1` the corresponding weight.
             type Item = &'a (Node, Weight);
             fn next(&mut self) -> Option<Self::Item> {
-                self.node_weight_pairs.next()
+                self.0.next()
             }
         }
 
         impl<'a> ::core::iter::DoubleEndedIterator for $quadrature_rule_iter<'a> {
             fn next_back(&mut self) -> Option<Self::Item> {
-                self.node_weight_pairs.next_back()
+                self.0.next_back()
             }
         }
 
@@ -215,26 +213,24 @@ macro_rules! impl_iterators {
         /// Created by the [`IntoIterator`] trait implementation of the quadrature rule struct.
         #[derive(Debug, Clone)]
         #[must_use = "iterators are lazy and do nothing unless consumed"]
-        pub struct $quadrature_rule_into_iter {
-            node_weight_pairs: ::std::vec::IntoIter<(Node, Weight)>,
-        }
+        pub struct $quadrature_rule_into_iter(::std::vec::IntoIter<(Node, Weight)>);
 
         impl ::core::iter::Iterator for $quadrature_rule_into_iter {
             /// Element `.0` is the node and element `.1` the corresponding weight.
             type Item = (Node, Weight);
             fn next(&mut self) -> Option<Self::Item> {
-                self.node_weight_pairs.next()
+                self.0.next()
             }
 
             #[inline]
             fn size_hint(&self) -> (usize, Option<usize>) {
-                self.node_weight_pairs.size_hint()
+                self.0.size_hint()
             }
         }
 
         impl ::core::iter::DoubleEndedIterator for $quadrature_rule_into_iter {
             fn next_back(&mut self) -> Option<Self::Item> {
-                self.node_weight_pairs.next_back()
+                self.0.next_back()
             }
         }
 
@@ -243,7 +239,7 @@ macro_rules! impl_iterators {
 
         impl $quadrature_rule_into_iter {
             pub(super) fn new(node_weight_pairs: ::std::vec::IntoIter<(Node, Weight)>) -> Self {
-                Self { node_weight_pairs }
+                Self(node_weight_pairs)
             }
 
             /// Views the underlying data as a subslice of the original data.
@@ -251,7 +247,7 @@ macro_rules! impl_iterators {
             /// See [`core::slice::Iter::as_slice`] for more information.
             #[inline]
             pub fn as_slice(&self) -> &[(Node, Weight)] {
-                self.node_weight_pairs.as_slice()
+                self.0.as_slice()
             }
         }
 

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -15,6 +15,8 @@ macro_rules! impl_data_api {
         // e.g. GaussLegendreIter.
         $quadrature_rule_iter:ident
     ) => {
+        // Implements functions for accessing the underlying data of the quadrature rule struct
+        // in a way the adheres to the API guidelines: <https://rust-lang.github.io/api-guidelines/naming.html>.
         // The functions in this impl block all have an #[inline] directive because they are trivial.
         impl $quadrature_rule {
             /// Returns an iterator over the nodes of the quadrature rule.
@@ -61,10 +63,10 @@ macro_rules! impl_data_api {
 }
 
 /// This macro defines the iterators used by the functions defined in the macro `impl_data_api`.
-/// It takes in the names of the same structs as that macro, plus the name of the iterator returned
-/// by the [`IntoIterator`] implementation.
+/// It takes in the names of the same structs as that macro, 
+/// plus the name of the iterator that should be returned by the [`IntoIterator`] implementation.
 /// These iterators can only be created in the module where the macro is called
-/// or the module above it (due to the `pub(super)`).
+/// or the module above it (due to the `pub(super)` marker on the constructors).
 #[doc(hidden)]
 #[macro_export]
 macro_rules! impl_iterators {
@@ -73,6 +75,7 @@ macro_rules! impl_iterators {
         $quadrature_rule_nodes:ident,
         $quadrature_rule_weights:ident,
         $quadrature_rule_iter:ident,
+        // The name of the iterator that should be returned by the IntoIterator trait.
         $quadrature_rule_into_iter:ident
     ) => {
         // region: QuadratureRuleNodes

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -1,6 +1,6 @@
 /// This macro implements the data access API for the given quadrature rule struct.
 /// It takes in the name of the quadrature rule as well as the names of the iterators
-/// over its nodes, weights, both (optional), and IntoIterator implementation.
+/// over its nodes, weights, both, and IntoIterator implementation.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! impl_data_api {

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -1,6 +1,6 @@
 /// This macro implements the data access API for the given quadrature rule struct.
-/// It takes in the name of the quadrature rule as well as the names of the iterators
-/// over its nodes, weights, and both. Also defines the iterator used by the IntoIterator implementation.
+/// It takes in the name of the quadrature rule struct as well as the names of the iterators
+/// over its nodes, weights, and both.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! impl_data_api {

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -7,7 +7,7 @@
 
 // The code in the macros uses fully qualified paths for every type, so it is quite verbose.
 // That is, instead of `usize` it uses `::core::primitive::usize` and so on. This makes it so that
-// the called of the macro doesn't have to import anything into the module in order for the macro to compile.
+// the caller of the macro doesn't have to import anything into the module in order for the macro to compile.
 
 /// This macro implements the data access API for the given quadrature rule struct.
 /// It takes in the name of the quadrature rule struct as well as the names of the iterators

--- a/src/hermite/iterators.rs
+++ b/src/hermite/iterators.rs
@@ -1,6 +1,6 @@
 //! This module contains the iterators produced by some of the functions on [`GaussHermite`].
 
 use super::GaussHermite;
-use crate::{impl_iterators, Node, Weight};
+use crate::impl_iterators;
 
 impl_iterators! {GaussHermite, GaussHermiteNodes, GaussHermiteWeights, GaussHermiteIter, GaussHermiteIntoIter}

--- a/src/hermite/iterators.rs
+++ b/src/hermite/iterators.rs
@@ -1,6 +1,6 @@
 //! This module contains the iterators produced by some of the functions on [`GaussHermite`].
 
 use super::GaussHermite;
-use crate::{impl_iterators, slice_map_iter_impl};
+use crate::{impl_iterators, slice_map_iter_impl, Node, Weight};
 
 impl_iterators! {GaussHermite, GaussHermiteNodes, GaussHermiteWeights, GaussHermiteIter, GaussHermiteIntoIter}

--- a/src/hermite/iterators.rs
+++ b/src/hermite/iterators.rs
@@ -1,6 +1,6 @@
 //! This module contains the iterators produced by some of the functions on [`GaussHermite`].
 
 use super::GaussHermite;
-use crate::{impl_iterators, slice_map_iter_impl, Node, Weight};
+use crate::{impl_iterators, Node, Weight};
 
 impl_iterators! {GaussHermite, GaussHermiteNodes, GaussHermiteWeights, GaussHermiteIter, GaussHermiteIntoIter}

--- a/src/hermite/iterators.rs
+++ b/src/hermite/iterators.rs
@@ -1,6 +1,6 @@
 //! This module contains the iterators produced by some of the functions on [`GaussHermite`].
 
 use super::GaussHermite;
-use crate::{impl_iterators, slice_iter_impl};
+use crate::{impl_iterators, slice_iter_map_impl};
 
 impl_iterators! {GaussHermite, GaussHermiteNodes, GaussHermiteWeights, GaussHermiteIter, GaussHermiteIntoIter}

--- a/src/hermite/iterators.rs
+++ b/src/hermite/iterators.rs
@@ -1,6 +1,5 @@
 //! This module contains the iterators produced by some of the functions on [`GaussHermite`].
 
 use super::GaussHermite;
-use crate::impl_iterators;
 
-impl_iterators! {GaussHermite, GaussHermiteNodes, GaussHermiteWeights, GaussHermiteIter, GaussHermiteIntoIter}
+crate::impl_iterators! {GaussHermite, GaussHermiteNodes, GaussHermiteWeights, GaussHermiteIter, GaussHermiteIntoIter}

--- a/src/hermite/iterators.rs
+++ b/src/hermite/iterators.rs
@@ -1,6 +1,6 @@
 //! This module contains the iterators produced by some of the functions on [`GaussHermite`].
 
 use super::GaussHermite;
-use crate::{impl_data_api, slice_iter_impl};
+use crate::{impl_iterators, slice_iter_impl};
 
-impl_data_api! {GaussHermite, GaussHermiteNodes, GaussHermiteWeights, GaussHermiteIter, GaussHermiteIntoIter}
+impl_iterators! {GaussHermite, GaussHermiteNodes, GaussHermiteWeights, GaussHermiteIter, GaussHermiteIntoIter}

--- a/src/hermite/iterators.rs
+++ b/src/hermite/iterators.rs
@@ -1,6 +1,6 @@
 //! This module contains the iterators produced by some of the functions on [`GaussHermite`].
 
 use super::GaussHermite;
-use crate::{impl_iterators, slice_iter_map_impl};
+use crate::{impl_iterators, slice_map_iter_impl};
 
 impl_iterators! {GaussHermite, GaussHermiteNodes, GaussHermiteWeights, GaussHermiteIter, GaussHermiteIntoIter}

--- a/src/hermite/mod.rs
+++ b/src/hermite/mod.rs
@@ -18,7 +18,7 @@
 pub mod iterators;
 use iterators::{GaussHermiteIter, GaussHermiteNodes, GaussHermiteWeights};
 
-use crate::{impl_data_api, DMatrixf64, PI};
+use crate::{impl_data_api, DMatrixf64, Node, Weight, PI};
 
 /// A Gauss-Hermite quadrature scheme.
 ///
@@ -40,7 +40,7 @@ use crate::{impl_data_api, DMatrixf64, PI};
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GaussHermite {
-    node_weight_pairs: Vec<(f64, f64)>,
+    node_weight_pairs: Vec<(Node, Weight)>,
 }
 
 impl GaussHermite {

--- a/src/hermite/mod.rs
+++ b/src/hermite/mod.rs
@@ -68,14 +68,14 @@ impl GaussHermite {
         // calculate eigenvalues & vectors
         let eigen = companion_matrix.symmetric_eigen();
 
-        // return nodes and weights as Vec<(f64, f64)>
+        // zip together the iterator over nodes with the one over weights and return as Vec<(f64, f64)>
         GaussHermite {
             node_weight_pairs: eigen
                 .eigenvalues
                 .iter()
                 .copied()
                 .zip(
-                    (eigen.eigenvectors.row(0).map(|x| x.powi(2)) * PI.sqrt())
+                    (eigen.eigenvectors.row(0).map(|x| x * x) * PI.sqrt())
                         .iter()
                         .copied(),
                 )

--- a/src/hermite/mod.rs
+++ b/src/hermite/mod.rs
@@ -16,8 +16,9 @@
 //! ```
 
 pub mod iterators;
+use iterators::{GaussHermiteIter, GaussHermiteNodes, GaussHermiteWeights};
 
-use crate::{DMatrixf64, PI};
+use crate::{impl_data_api, DMatrixf64, PI};
 
 /// A Gauss-Hermite quadrature scheme.
 ///
@@ -90,6 +91,8 @@ impl GaussHermite {
         result
     }
 }
+
+impl_data_api! {GaussHermite, GaussHermiteNodes, GaussHermiteWeights, GaussHermiteIter}
 
 #[cfg(test)]
 mod tests {

--- a/src/jacobi/iterators.rs
+++ b/src/jacobi/iterators.rs
@@ -1,6 +1,6 @@
 //! This module contains the iterators produced by some of the functions on [`GaussJacobi`].
 
 use super::GaussJacobi;
-use crate::{impl_iterators, slice_iter_map_impl};
+use crate::{impl_iterators, slice_map_iter_impl};
 
 impl_iterators! {GaussJacobi, GaussJacobiNodes, GaussJacobiWeights, GaussJacobiIter, GaussJacobiIntoIter}

--- a/src/jacobi/iterators.rs
+++ b/src/jacobi/iterators.rs
@@ -1,6 +1,5 @@
 //! This module contains the iterators produced by some of the functions on [`GaussJacobi`].
 
 use super::GaussJacobi;
-use crate::impl_iterators;
 
-impl_iterators! {GaussJacobi, GaussJacobiNodes, GaussJacobiWeights, GaussJacobiIter, GaussJacobiIntoIter}
+crate::impl_iterators! {GaussJacobi, GaussJacobiNodes, GaussJacobiWeights, GaussJacobiIter, GaussJacobiIntoIter}

--- a/src/jacobi/iterators.rs
+++ b/src/jacobi/iterators.rs
@@ -1,6 +1,6 @@
 //! This module contains the iterators produced by some of the functions on [`GaussJacobi`].
 
 use super::GaussJacobi;
-use crate::{impl_iterators, slice_map_iter_impl, Node, Weight};
+use crate::{impl_iterators, Node, Weight};
 
 impl_iterators! {GaussJacobi, GaussJacobiNodes, GaussJacobiWeights, GaussJacobiIter, GaussJacobiIntoIter}

--- a/src/jacobi/iterators.rs
+++ b/src/jacobi/iterators.rs
@@ -1,6 +1,6 @@
 //! This module contains the iterators produced by some of the functions on [`GaussJacobi`].
 
 use super::GaussJacobi;
-use crate::{impl_data_api, slice_iter_impl};
+use crate::{impl_iterators, slice_iter_impl};
 
-impl_data_api! {GaussJacobi, GaussJacobiNodes, GaussJacobiWeights, GaussJacobiIter, GaussJacobiIntoIter}
+impl_iterators! {GaussJacobi, GaussJacobiNodes, GaussJacobiWeights, GaussJacobiIter, GaussJacobiIntoIter}

--- a/src/jacobi/iterators.rs
+++ b/src/jacobi/iterators.rs
@@ -1,0 +1,6 @@
+//! This module contains the iterators produced by some of the functions on [`GaussJacobi`].
+
+use super::GaussJacobi;
+use crate::{impl_data_api, slice_iter_impl};
+
+impl_data_api!{GaussJacobi, GaussJacobiNodes, GaussJacobiWeights, GaussJacobiIter, GaussJacobiIntoIter}

--- a/src/jacobi/iterators.rs
+++ b/src/jacobi/iterators.rs
@@ -1,6 +1,6 @@
 //! This module contains the iterators produced by some of the functions on [`GaussJacobi`].
 
 use super::GaussJacobi;
-use crate::{impl_iterators, slice_iter_impl};
+use crate::{impl_iterators, slice_iter_map_impl};
 
 impl_iterators! {GaussJacobi, GaussJacobiNodes, GaussJacobiWeights, GaussJacobiIter, GaussJacobiIntoIter}

--- a/src/jacobi/iterators.rs
+++ b/src/jacobi/iterators.rs
@@ -1,6 +1,6 @@
 //! This module contains the iterators produced by some of the functions on [`GaussJacobi`].
 
 use super::GaussJacobi;
-use crate::{impl_iterators, Node, Weight};
+use crate::impl_iterators;
 
 impl_iterators! {GaussJacobi, GaussJacobiNodes, GaussJacobiWeights, GaussJacobiIter, GaussJacobiIntoIter}

--- a/src/jacobi/iterators.rs
+++ b/src/jacobi/iterators.rs
@@ -3,4 +3,4 @@
 use super::GaussJacobi;
 use crate::{impl_data_api, slice_iter_impl};
 
-impl_data_api!{GaussJacobi, GaussJacobiNodes, GaussJacobiWeights, GaussJacobiIter, GaussJacobiIntoIter}
+impl_data_api! {GaussJacobi, GaussJacobiNodes, GaussJacobiWeights, GaussJacobiIter, GaussJacobiIntoIter}

--- a/src/jacobi/iterators.rs
+++ b/src/jacobi/iterators.rs
@@ -1,6 +1,6 @@
 //! This module contains the iterators produced by some of the functions on [`GaussJacobi`].
 
 use super::GaussJacobi;
-use crate::{impl_iterators, slice_map_iter_impl};
+use crate::{impl_iterators, slice_map_iter_impl, Node, Weight};
 
 impl_iterators! {GaussJacobi, GaussJacobiNodes, GaussJacobiWeights, GaussJacobiIter, GaussJacobiIntoIter}

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -19,9 +19,10 @@
 //! ```
 
 pub mod iterators;
+use iterators::{GaussJacobiIter, GaussJacobiNodes, GaussJacobiWeights};
 
 use crate::gamma::gamma;
-use crate::DMatrixf64;
+use crate::{impl_data_api, DMatrixf64};
 
 /// A Gauss-Jacobi quadrature scheme.
 ///
@@ -158,6 +159,8 @@ impl GaussJacobi {
         self.beta
     }
 }
+
+impl_data_api! {GaussJacobi, GaussJacobiNodes, GaussJacobiWeights, GaussJacobiIter}
 
 #[cfg(test)]
 mod tests {

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -52,20 +52,12 @@ impl GaussJacobi {
     /// Initializes Gauss-Jacobi quadrature rule of the given degree by computing the nodes and weights
     /// needed for the given `alpha` and `beta`.
     ///
-    /// # Panics
-    /// Panics if degree of quadrature is smaller than 2, or if alpha or beta are smaller than -1
-    pub fn new(deg: usize, alpha: f64, beta: f64) -> GaussJacobi {
-        let (nodes, weights) = GaussJacobi::nodes_and_weights(deg, alpha, beta);
-
-        GaussJacobi { nodes, weights }
-    }
-
-    /// Apply Golub-Welsch algorithm to determine Gauss-Jacobi nodes & weights
-    /// see Gil, Segura, Temme - Numerical Methods for Special Functions
+    /// Applies Golub-Welsch algorithm to determine Gauss-Jacobi nodes & weights.
+    /// See Gil, Segura, Temme - Numerical Methods for Special Functions
     ///
     /// # Panics
     /// Panics if degree of quadrature is smaller than 2, or if alpha or beta are smaller than -1
-    pub fn nodes_and_weights(deg: usize, alpha: f64, beta: f64) -> (Vec<f64>, Vec<f64>) {
+    pub fn new(deg: usize, alpha: f64, beta: f64) -> GaussJacobi {
         if alpha < -1.0 || beta < -1.0 {
             panic!("Gauss-Jacobi quadrature needs alpha > -1.0 and beta > -1.0");
         }
@@ -117,7 +109,8 @@ impl GaussJacobi {
         if deg & 1 == 1 {
             nodes[deg / 2] = 0.0;
         }
-        (nodes, weights)
+
+        GaussJacobi { nodes, weights }
     }
 
     fn argument_transformation(x: f64, a: f64, b: f64) -> f64 {
@@ -152,7 +145,7 @@ mod tests {
     use super::*;
     #[test]
     fn golub_welsch_5_alpha_0_beta_0() {
-        let (x, w) = GaussJacobi::nodes_and_weights(5, 0.0, 0.0);
+        let (x, w) = GaussJacobi::new(5, 0.0, 0.0).into_nodes_and_weights();
         let x_should = [
             -0.906_179_845_938_664,
             -0.538_469_310_105_683_1,
@@ -177,7 +170,7 @@ mod tests {
 
     #[test]
     fn golub_welsch_2_alpha_1_beta_0() {
-        let (x, w) = GaussJacobi::nodes_and_weights(2, 1.0, 0.0);
+        let (x, w) = GaussJacobi::new(2, 1.0, 0.0).into_nodes_and_weights();
         let x_should = [-0.689_897_948_556_635_7, 0.289_897_948_556_635_64];
         let w_should = [1.272_165_526_975_908_7, 0.727_834_473_024_091_3];
         for (i, x_val) in x_should.iter().enumerate() {
@@ -190,7 +183,7 @@ mod tests {
 
     #[test]
     fn golub_welsch_5_alpha_1_beta_0() {
-        let (x, w) = GaussJacobi::nodes_and_weights(5, 1.0, 0.0);
+        let (x, w) = GaussJacobi::new(5, 1.0, 0.0).into_nodes_and_weights();
         let x_should = [
             -0.920_380_285_897_062_6,
             -0.603_973_164_252_783_7,
@@ -215,7 +208,7 @@ mod tests {
 
     #[test]
     fn golub_welsch_5_alpha_0_beta_1() {
-        let (x, w) = GaussJacobi::nodes_and_weights(5, 0.0, 1.0);
+        let (x, w) = GaussJacobi::new(5, 0.0, 1.0).into_nodes_and_weights();
         let x_should = [
             -0.802_929_828_402_347_2,
             -0.390_928_546_707_272_2,
@@ -240,7 +233,7 @@ mod tests {
 
     #[test]
     fn golub_welsch_50_alpha_42_beta_23() {
-        let (x, w) = GaussJacobi::nodes_and_weights(50, 42.0, 23.0);
+        let (x, w) = GaussJacobi::new(50, 42.0, 23.0).into_nodes_and_weights();
         let x_should = [
             -0.936_528_233_152_541_2,
             -0.914_340_864_546_088_5,

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -44,8 +44,8 @@ use crate::DMatrixf64;
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GaussJacobi {
-    pub nodes: Vec<f64>,
-    pub weights: Vec<f64>,
+    nodes: Vec<f64>,
+    weights: Vec<f64>,
 }
 
 impl GaussJacobi {

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -108,7 +108,7 @@ impl GaussJacobi {
                     .copied(),
             )
             .collect();
-        node_weight_pairs.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+        node_weight_pairs.sort_unstable_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
 
         // TO FIX: implement correction
         // eigenvalue algorithm has problem to get the zero eigenvalue for odd degrees

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -18,6 +18,8 @@
 //! assert_abs_diff_eq!(integral, -0.4207987746500829, epsilon = 1e-14);
 //! ```
 
+pub mod iterators;
+
 use crate::gamma::gamma;
 use crate::DMatrixf64;
 

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -46,6 +46,8 @@ use crate::DMatrixf64;
 pub struct GaussJacobi {
     nodes: Vec<f64>,
     weights: Vec<f64>,
+    alpha: f64,
+    beta: f64,
 }
 
 impl GaussJacobi {
@@ -110,7 +112,12 @@ impl GaussJacobi {
             nodes[deg / 2] = 0.0;
         }
 
-        GaussJacobi { nodes, weights }
+        GaussJacobi {
+            nodes,
+            weights,
+            alpha,
+            beta,
+        }
     }
 
     fn argument_transformation(x: f64, a: f64, b: f64) -> f64 {
@@ -137,6 +144,18 @@ impl GaussJacobi {
             })
             .sum();
         GaussJacobi::scale_factor(a, b) * result
+    }
+
+    /// Returns the value of the `alpha` parameter.
+    #[inline]
+    pub const fn alpha(&self) -> f64 {
+        self.alpha
+    }
+
+    /// Returns the value of the `beta` parameter.
+    #[inline]
+    pub const fn beta(&self) -> f64 {
+        self.beta
     }
 }
 

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -207,10 +207,7 @@ mod tests {
 
     #[test]
     fn golub_welsch_5_alpha_1_beta_0() {
-        let (x, w): (Vec<_>, Vec<_>) = GaussJacobi::new(5, 1.0, 0.0)
-            .into_iter()
-            .into_iter()
-            .unzip();
+        let (x, w): (Vec<_>, Vec<_>) = GaussJacobi::new(5, 1.0, 0.0).into_iter().unzip();
         let x_should = [
             -0.920_380_285_897_062_6,
             -0.603_973_164_252_783_7,

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -22,7 +22,7 @@ pub mod iterators;
 use iterators::{GaussJacobiIter, GaussJacobiNodes, GaussJacobiWeights};
 
 use crate::gamma::gamma;
-use crate::{impl_data_api, DMatrixf64};
+use crate::{impl_data_api, DMatrixf64, Node, Weight};
 
 /// A Gauss-Jacobi quadrature scheme.
 ///
@@ -45,7 +45,7 @@ use crate::{impl_data_api, DMatrixf64};
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GaussJacobi {
-    node_weight_pairs: Vec<(f64, f64)>,
+    node_weight_pairs: Vec<(Node, Weight)>,
     alpha: f64,
     beta: f64,
 }

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -52,7 +52,7 @@ impl GaussJacobi {
     /// Initializes Gauss-Jacobi quadrature rule of the given degree by computing the nodes and weights
     /// needed for the given `alpha` and `beta`.
     ///
-    /// Applies Golub-Welsch algorithm to determine Gauss-Jacobi nodes & weights.
+    /// Applies the Golub-Welsch algorithm to determine Gauss-Jacobi nodes & weights.
     /// See Gil, Segura, Temme - Numerical Methods for Special Functions
     ///
     /// # Panics

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -113,7 +113,7 @@ impl GaussJacobi {
         // TO FIX: implement correction
         // eigenvalue algorithm has problem to get the zero eigenvalue for odd degrees
         // for now... manual correction seems to do the trick
-        if deg & 1 == 1 {
+        if deg % 2 == 1 {
             node_weight_pairs[deg / 2].0 = 0.0;
         }
 

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -100,11 +100,11 @@ impl GaussJacobi {
         // zip together the iterator over nodes with the one over weights and return as Vec<(f64, f64)>
         let mut node_weight_pairs: Vec<(f64, f64)> = eigen
             .eigenvalues
-            .into_iter()
+            .iter()
             .copied()
             .zip(
                 (eigen.eigenvectors.row(0).map(|x| x * x) * scale_factor)
-                    .into_iter()
+                    .iter()
                     .copied(),
             )
             .collect();

--- a/src/laguerre/iterators.rs
+++ b/src/laguerre/iterators.rs
@@ -1,6 +1,5 @@
 //! This module contains the iterators produced by some of the functions on [`GaussLaguerre`].
 
 use super::GaussLaguerre;
-use crate::impl_iterators;
 
-impl_iterators! {GaussLaguerre, GaussLaguerreNodes, GaussLaguerreWeights, GaussLaguerreIter, GaussLaguerreIntoIter}
+crate::impl_iterators! {GaussLaguerre, GaussLaguerreNodes, GaussLaguerreWeights, GaussLaguerreIter, GaussLaguerreIntoIter}

--- a/src/laguerre/iterators.rs
+++ b/src/laguerre/iterators.rs
@@ -1,0 +1,6 @@
+//! This module contains the iterators produced by some of the functions on [`GaussLaguerre`].
+
+use super::GaussLaguerre;
+use crate::{impl_data_api, slice_iter_impl};
+
+impl_data_api! {GaussLaguerre, GaussLaguerreNodes, GaussLaguerreWeights, GaussLaguerreIter, GaussLaguerreIntoIter}

--- a/src/laguerre/iterators.rs
+++ b/src/laguerre/iterators.rs
@@ -1,6 +1,6 @@
 //! This module contains the iterators produced by some of the functions on [`GaussLaguerre`].
 
 use super::GaussLaguerre;
-use crate::{impl_iterators, slice_map_iter_impl, Node, Weight};
+use crate::{impl_iterators, Node, Weight};
 
 impl_iterators! {GaussLaguerre, GaussLaguerreNodes, GaussLaguerreWeights, GaussLaguerreIter, GaussLaguerreIntoIter}

--- a/src/laguerre/iterators.rs
+++ b/src/laguerre/iterators.rs
@@ -1,6 +1,6 @@
 //! This module contains the iterators produced by some of the functions on [`GaussLaguerre`].
 
 use super::GaussLaguerre;
-use crate::{impl_iterators, Node, Weight};
+use crate::impl_iterators;
 
 impl_iterators! {GaussLaguerre, GaussLaguerreNodes, GaussLaguerreWeights, GaussLaguerreIter, GaussLaguerreIntoIter}

--- a/src/laguerre/iterators.rs
+++ b/src/laguerre/iterators.rs
@@ -1,6 +1,6 @@
 //! This module contains the iterators produced by some of the functions on [`GaussLaguerre`].
 
 use super::GaussLaguerre;
-use crate::{impl_iterators, slice_map_iter_impl};
+use crate::{impl_iterators, slice_map_iter_impl, Node, Weight};
 
 impl_iterators! {GaussLaguerre, GaussLaguerreNodes, GaussLaguerreWeights, GaussLaguerreIter, GaussLaguerreIntoIter}

--- a/src/laguerre/iterators.rs
+++ b/src/laguerre/iterators.rs
@@ -1,6 +1,6 @@
 //! This module contains the iterators produced by some of the functions on [`GaussLaguerre`].
 
 use super::GaussLaguerre;
-use crate::{impl_iterators, slice_iter_map_impl};
+use crate::{impl_iterators, slice_map_iter_impl};
 
 impl_iterators! {GaussLaguerre, GaussLaguerreNodes, GaussLaguerreWeights, GaussLaguerreIter, GaussLaguerreIntoIter}

--- a/src/laguerre/iterators.rs
+++ b/src/laguerre/iterators.rs
@@ -1,6 +1,6 @@
 //! This module contains the iterators produced by some of the functions on [`GaussLaguerre`].
 
 use super::GaussLaguerre;
-use crate::{impl_iterators, slice_iter_impl};
+use crate::{impl_iterators, slice_iter_map_impl};
 
 impl_iterators! {GaussLaguerre, GaussLaguerreNodes, GaussLaguerreWeights, GaussLaguerreIter, GaussLaguerreIntoIter}

--- a/src/laguerre/iterators.rs
+++ b/src/laguerre/iterators.rs
@@ -1,6 +1,6 @@
 //! This module contains the iterators produced by some of the functions on [`GaussLaguerre`].
 
 use super::GaussLaguerre;
-use crate::{impl_data_api, slice_iter_impl};
+use crate::{impl_iterators, slice_iter_impl};
 
-impl_data_api! {GaussLaguerre, GaussLaguerreNodes, GaussLaguerreWeights, GaussLaguerreIter, GaussLaguerreIntoIter}
+impl_iterators! {GaussLaguerre, GaussLaguerreNodes, GaussLaguerreWeights, GaussLaguerreIter, GaussLaguerreIntoIter}

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -41,6 +41,7 @@ use crate::DMatrixf64;
 pub struct GaussLaguerre {
     nodes: Vec<f64>,
     weights: Vec<f64>,
+    alpha: f64,
 }
 
 impl GaussLaguerre {
@@ -98,7 +99,11 @@ impl GaussLaguerre {
         both.sort_by(|a, b| a.0.partial_cmp(b.0).unwrap());
         let (nodes, weights): (Vec<f64>, Vec<f64>) = both.iter().cloned().unzip();
 
-        GaussLaguerre { nodes, weights }
+        GaussLaguerre {
+            nodes,
+            weights,
+            alpha,
+        }
     }
 
     /// Perform quadrature of  
@@ -115,6 +120,12 @@ impl GaussLaguerre {
             .map(|(&x_val, w_val)| integrand(x_val) * w_val)
             .sum();
         result
+    }
+
+    /// Returns the value of the `alpha` parameter of the rule.
+    #[inline]
+    pub const fn alpha(&self) -> f64 {
+        self.alpha
     }
 }
 

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -18,7 +18,7 @@ pub mod iterators;
 use iterators::{GaussLaguerreIter, GaussLaguerreNodes, GaussLaguerreWeights};
 
 use crate::gamma::gamma;
-use crate::{impl_data_api, DMatrixf64};
+use crate::{impl_data_api, DMatrixf64, Node, Weight};
 
 /// A Gauss-Laguerre quadrature scheme.
 ///
@@ -40,7 +40,7 @@ use crate::{impl_data_api, DMatrixf64};
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GaussLaguerre {
-    node_weight_pairs: Vec<(f64, f64)>,
+    node_weight_pairs: Vec<(Node, Weight)>,
     alpha: f64,
 }
 

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -99,7 +99,7 @@ impl GaussLaguerre {
                     .copied(),
             )
             .collect();
-        node_weight_pairs.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+        node_weight_pairs.sort_unstable_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
 
         GaussLaguerre {
             node_weight_pairs,

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -58,9 +58,6 @@ impl GaussLaguerre {
     ///
     /// # Panics
     /// Panics if degree of quadrature is smaller than 2, or if alpha is smaller than -1
-    ///
-    /// # Panics
-    /// Panics if degree of quadrature is smaller than 2, or if alpha is smaller than -1
     pub fn new(deg: usize, alpha: f64) -> GaussLaguerre {
         if alpha < -1.0 {
             panic!("Gauss-Laguerre quadrature needs alpha > -1.0");

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -40,8 +40,7 @@ use crate::{impl_data_api, DMatrixf64};
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GaussLaguerre {
-    nodes: Vec<f64>,
-    weights: Vec<f64>,
+    node_weight_pairs: Vec<(f64, f64)>,
     alpha: f64,
 }
 
@@ -101,8 +100,7 @@ impl GaussLaguerre {
         let (nodes, weights): (Vec<f64>, Vec<f64>) = both.iter().cloned().unzip();
 
         GaussLaguerre {
-            nodes,
-            weights,
+            node_weight_pairs: nodes.into_iter().zip(weights.into_iter()).collect(),
             alpha,
         }
     }
@@ -115,10 +113,9 @@ impl GaussLaguerre {
         F: Fn(f64) -> f64,
     {
         let result: f64 = self
-            .nodes
+            .node_weight_pairs
             .iter()
-            .zip(self.weights.iter())
-            .map(|(&x_val, w_val)| integrand(x_val) * w_val)
+            .map(|(x_val, w_val)| integrand(*x_val) * w_val)
             .sum();
         result
     }
@@ -138,7 +135,7 @@ mod tests {
 
     #[test]
     fn golub_welsch_2_alpha_5() {
-        let (x, w) = GaussLaguerre::new(2, 5.0).into_nodes_and_weights();
+        let (x, w): (Vec<_>, Vec<_>) = GaussLaguerre::new(2, 5.0).into_iter().unzip();
         let x_should = [4.354_248_688_935_409, 9.645_751_311_064_59];
         let w_should = [82.677_868_380_553_63, 37.322_131_619_446_37];
         for (i, x_val) in x_should.iter().enumerate() {
@@ -151,7 +148,7 @@ mod tests {
 
     #[test]
     fn golub_welsch_3_alpha_0() {
-        let (x, w) = GaussLaguerre::new(3, 0.0).into_nodes_and_weights();
+        let (x, w): (Vec<_>, Vec<_>) = GaussLaguerre::new(3, 0.0).into_iter().unzip();
         let x_should = [
             0.415_774_556_783_479_1,
             2.294_280_360_279_042,
@@ -172,7 +169,7 @@ mod tests {
 
     #[test]
     fn golub_welsch_3_alpha_1_5() {
-        let (x, w) = GaussLaguerre::new(3, 1.5).into_nodes_and_weights();
+        let (x, w): (Vec<_>, Vec<_>) = GaussLaguerre::new(3, 1.5).into_iter().unzip();
         let x_should = [
             1.220_402_317_558_883_8,
             3.808_880_721_467_068,
@@ -193,7 +190,7 @@ mod tests {
 
     #[test]
     fn golub_welsch_5_alpha_negative() {
-        let (x, w) = GaussLaguerre::new(5, -0.9).into_nodes_and_weights();
+        let (x, w): (Vec<_>, Vec<_>) = GaussLaguerre::new(5, -0.9).into_iter().unzip();
         let x_should = [
             0.020_777_151_319_288_104,
             0.808_997_536_134_602_1,

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -15,9 +15,10 @@
 //! ```
 
 pub mod iterators;
+use iterators::{GaussLaguerreIter, GaussLaguerreNodes, GaussLaguerreWeights};
 
 use crate::gamma::gamma;
-use crate::DMatrixf64;
+use crate::{impl_data_api, DMatrixf64};
 
 /// A Gauss-Laguerre quadrature scheme.
 ///
@@ -128,6 +129,8 @@ impl GaussLaguerre {
         self.alpha
     }
 }
+
+impl_data_api! {GaussLaguerre, GaussLaguerreNodes, GaussLaguerreWeights, GaussLaguerreIter}
 
 #[cfg(test)]
 mod tests {

--- a/src/legendre/iterators.rs
+++ b/src/legendre/iterators.rs
@@ -1,6 +1,5 @@
 //! This module contains the iterators produced by some of the functions on [`GaussLegendre`].
 
 use super::GaussLegendre;
-use crate::impl_iterators;
 
-impl_iterators! {GaussLegendre, GaussLegendreNodes, GaussLegendreWeights, GaussLegendreIter, GaussLegendreIntoIter}
+crate::impl_iterators! {GaussLegendre, GaussLegendreNodes, GaussLegendreWeights, GaussLegendreIter, GaussLegendreIntoIter}

--- a/src/legendre/iterators.rs
+++ b/src/legendre/iterators.rs
@@ -1,6 +1,6 @@
 //! This module contains the iterators produced by some of the functions on [`GaussLegendre`].
 
 use super::GaussLegendre;
-use crate::{impl_iterators, slice_iter_map_impl};
+use crate::{impl_iterators, slice_map_iter_impl};
 
 impl_iterators! {GaussLegendre, GaussLegendreNodes, GaussLegendreWeights, GaussLegendreIter, GaussLegendreIntoIter}

--- a/src/legendre/iterators.rs
+++ b/src/legendre/iterators.rs
@@ -1,6 +1,6 @@
 //! This module contains the iterators produced by some of the functions on [`GaussLegendre`].
 
 use super::GaussLegendre;
-use crate::{impl_iterators, slice_iter_impl};
+use crate::{impl_iterators, slice_iter_map_impl};
 
 impl_iterators! {GaussLegendre, GaussLegendreNodes, GaussLegendreWeights, GaussLegendreIter, GaussLegendreIntoIter}

--- a/src/legendre/iterators.rs
+++ b/src/legendre/iterators.rs
@@ -1,6 +1,6 @@
 //! This module contains the iterators produced by some of the functions on [`GaussLegendre`].
 
 use super::GaussLegendre;
-use crate::{impl_iterators, Node, Weight};
+use crate::impl_iterators;
 
 impl_iterators! {GaussLegendre, GaussLegendreNodes, GaussLegendreWeights, GaussLegendreIter, GaussLegendreIntoIter}

--- a/src/legendre/iterators.rs
+++ b/src/legendre/iterators.rs
@@ -1,6 +1,6 @@
 //! This module contains the iterators produced by some of the functions on [`GaussLegendre`].
 
 use super::GaussLegendre;
-use crate::{impl_data_api, slice_iter_impl};
+use crate::{impl_iterators, slice_iter_impl};
 
-impl_data_api! {GaussLegendre, GaussLegendreNodes, GaussLegendreWeights, GaussLegendreIter, GaussLegendreIntoIter}
+impl_iterators! {GaussLegendre, GaussLegendreNodes, GaussLegendreWeights, GaussLegendreIter, GaussLegendreIntoIter}

--- a/src/legendre/iterators.rs
+++ b/src/legendre/iterators.rs
@@ -1,6 +1,6 @@
 //! This module contains the iterators produced by some of the functions on [`GaussLegendre`].
 
 use super::GaussLegendre;
-use crate::{impl_iterators, slice_map_iter_impl, Node, Weight};
+use crate::{impl_iterators, Node, Weight};
 
 impl_iterators! {GaussLegendre, GaussLegendreNodes, GaussLegendreWeights, GaussLegendreIter, GaussLegendreIntoIter}

--- a/src/legendre/iterators.rs
+++ b/src/legendre/iterators.rs
@@ -1,6 +1,6 @@
 //! This module contains the iterators produced by some of the functions on [`GaussLegendre`].
 
 use super::GaussLegendre;
-use crate::{impl_iterators, slice_map_iter_impl};
+use crate::{impl_iterators, slice_map_iter_impl, Node, Weight};
 
 impl_iterators! {GaussLegendre, GaussLegendreNodes, GaussLegendreWeights, GaussLegendreIter, GaussLegendreIntoIter}

--- a/src/legendre/mod.rs
+++ b/src/legendre/mod.rs
@@ -22,8 +22,11 @@
 //! ```
 
 pub mod iterators;
+use iterators::{GaussLegendreIter, GaussLegendreNodes, GaussLegendreWeights};
 
 use bogaert::NodeWeightPair;
+
+use crate::impl_data_api;
 
 /// A Gauss-Legendre quadrature scheme.
 ///
@@ -99,6 +102,8 @@ impl GaussLegendre {
         Self::scale_factor(a, b) * result
     }
 }
+
+impl_data_api! {GaussLegendre, GaussLegendreNodes, GaussLegendreWeights, GaussLegendreIter}
 
 /// This algorithm is based on an expansion of Legendre polynomials in terms of Bessel functions
 /// where for large degrees only the first terms in the expansion matter. This means that

--- a/src/legendre/mod.rs
+++ b/src/legendre/mod.rs
@@ -26,7 +26,7 @@ use iterators::{GaussLegendreIter, GaussLegendreNodes, GaussLegendreWeights};
 
 use bogaert::NodeWeightPair;
 
-use crate::impl_data_api;
+use crate::{impl_data_api, Node, Weight};
 
 /// A Gauss-Legendre quadrature scheme.
 ///
@@ -57,7 +57,7 @@ use crate::impl_data_api;
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GaussLegendre {
-    node_weight_pairs: Vec<(f64, f64)>,
+    node_weight_pairs: Vec<(Node, Weight)>,
 }
 
 impl GaussLegendre {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,8 +129,8 @@
 //! `serde`: implements the [`Serialize`](serde::Serialize) and [`Deserialize`](serde::Deserialize) traits from
 //! the [`serde`](https://crates.io/crates/serde) crate for the quatrature rule structs.
 
-use nalgebra::{Dynamic, Matrix, VecStorage};
-type DMatrixf64 = Matrix<f64, Dynamic, Dynamic, VecStorage<f64, Dynamic, Dynamic>>;
+use nalgebra::{Dyn, Matrix, VecStorage};
+type DMatrixf64 = Matrix<f64, Dyn, Dyn, VecStorage<f64, Dyn, Dyn>>;
 use core::f64::consts::PI;
 
 mod data_api;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,9 +130,8 @@
 //! the [`serde`](https://crates.io/crates/serde) crate for the quatrature rule structs.
 
 use nalgebra::{Dynamic, Matrix, VecStorage};
-pub type DMatrixf64 = Matrix<f64, Dynamic, Dynamic, VecStorage<f64, Dynamic, Dynamic>>;
-#[doc(inline)]
-pub use core::f64::consts::PI;
+type DMatrixf64 = Matrix<f64, Dynamic, Dynamic, VecStorage<f64, Dynamic, Dynamic>>;
+use core::f64::consts::PI;
 
 mod data_api;
 mod gamma;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,6 +144,7 @@ pub mod legendre;
 pub mod midpoint;
 pub mod simpson;
 
+pub use data_api::{Node, NodeWeightPair, Weight};
 #[doc(inline)]
 pub use hermite::GaussHermite;
 #[doc(inline)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,6 @@ pub mod legendre;
 pub mod midpoint;
 pub mod simpson;
 
-pub use data_api::{Node, Weight};
 #[doc(inline)]
 pub use hermite::GaussHermite;
 #[doc(inline)]
@@ -157,3 +156,8 @@ pub use legendre::GaussLegendre;
 pub use midpoint::Midpoint;
 #[doc(inline)]
 pub use simpson::Simpson;
+
+/// A node in a quadrature rule.
+pub type Node = f64;
+/// A weight in a quadrature rule.
+pub type Weight = f64;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,7 @@ pub mod legendre;
 pub mod midpoint;
 pub mod simpson;
 
-pub use data_api::{Node, NodeWeightPair, Weight};
+pub use data_api::{Node, Weight};
 #[doc(inline)]
 pub use hermite::GaussHermite;
 #[doc(inline)]

--- a/src/midpoint/iterators.rs
+++ b/src/midpoint/iterators.rs
@@ -4,8 +4,8 @@
 use crate::Node;
 use core::iter::FusedIterator;
 
-/// An iterator of the nodes of a [`Midpoint`](super::Midpoint) instance created by
-/// [`Midpoint::iter`](super::Midpoint::iter).
+/// An iterator of the nodes of a [`Midpoint`](super::Midpoint) instance.
+/// Created by the [`Midpoint::iter`](super::Midpoint::iter) function, see it for more information.
 #[derive(Debug, Clone)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 pub struct MidpointIter<'a>(core::slice::Iter<'a, f64>);

--- a/src/midpoint/iterators.rs
+++ b/src/midpoint/iterators.rs
@@ -20,7 +20,7 @@ impl<'a> MidpointIter<'a> {
     ///
     /// See [`core::slice::Iter::as_slice`] for more information.
     #[inline]
-    pub fn as_slice(&self) -> &[Node] {
+    pub fn as_slice(&self) -> &'a [Node] {
         self.0.as_slice()
     }
 }

--- a/src/midpoint/iterators.rs
+++ b/src/midpoint/iterators.rs
@@ -1,0 +1,36 @@
+//! This crate contains the implementation of the iterators that
+//! can be returned by method calls on a [`Midpoint`](super::Midpoint) instance.
+
+use crate::Node;
+use core::iter::FusedIterator;
+
+/// An iterator of the nodes of a [`Midpoint`](super::Midpoint) instance created by
+/// [`Midpoint::iter`](super::Midpoint::iter).
+#[derive(Debug, Clone)]
+pub struct MidpointIter<'a>(core::slice::Iter<'a, f64>);
+
+impl<'a> MidpointIter<'a> {
+    pub(super) fn new(iter: core::slice::Iter<'a, f64>) -> Self {
+        Self(iter)
+    }
+}
+
+impl<'a> Iterator for MidpointIter<'a> {
+    type Item = &'a Node;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+impl<'a> DoubleEndedIterator for MidpointIter<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.0.next_back()
+    }
+}
+
+impl<'a> ExactSizeIterator for MidpointIter<'a> {}
+impl<'a> FusedIterator for MidpointIter<'a> {}

--- a/src/midpoint/iterators.rs
+++ b/src/midpoint/iterators.rs
@@ -11,8 +11,17 @@ use core::iter::FusedIterator;
 pub struct MidpointIter<'a>(core::slice::Iter<'a, f64>);
 
 impl<'a> MidpointIter<'a> {
+    #[inline]
     pub(super) fn new(iter: core::slice::Iter<'a, f64>) -> Self {
         Self(iter)
+    }
+
+    /// Views the underlying data as a subslice of the original data.
+    ///
+    /// See [`core::slice::Iter::as_slice`] for more information.
+    #[inline]
+    pub fn as_slice(&self) -> &[Node] {
+        self.0.as_slice()
     }
 }
 
@@ -22,6 +31,7 @@ impl<'a> Iterator for MidpointIter<'a> {
         self.0.next()
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.0.size_hint()
     }

--- a/src/midpoint/iterators.rs
+++ b/src/midpoint/iterators.rs
@@ -7,6 +7,7 @@ use core::iter::FusedIterator;
 /// An iterator of the nodes of a [`Midpoint`](super::Midpoint) instance created by
 /// [`Midpoint::iter`](super::Midpoint::iter).
 #[derive(Debug, Clone)]
+#[must_use = "iterators are lazy and do nothing unless consumed"]
 pub struct MidpointIter<'a>(core::slice::Iter<'a, f64>);
 
 impl<'a> MidpointIter<'a> {

--- a/src/midpoint/iterators.rs
+++ b/src/midpoint/iterators.rs
@@ -3,16 +3,17 @@
 
 use crate::Node;
 use core::iter::FusedIterator;
+use core::slice::Iter;
 
 /// An iterator of the nodes of a [`Midpoint`](super::Midpoint) instance.
 /// Created by the [`Midpoint::iter`](super::Midpoint::iter) function, see it for more information.
 #[derive(Debug, Clone)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
-pub struct MidpointIter<'a>(core::slice::Iter<'a, f64>);
+pub struct MidpointIter<'a>(Iter<'a, f64>);
 
 impl<'a> MidpointIter<'a> {
     #[inline]
-    pub(super) fn new(iter: core::slice::Iter<'a, f64>) -> Self {
+    pub(super) fn new(iter: Iter<'a, f64>) -> Self {
         Self(iter)
     }
 

--- a/src/midpoint/mod.rs
+++ b/src/midpoint/mod.rs
@@ -74,7 +74,7 @@ impl Midpoint {
     }
 
     /// Returns an iterator over the nodes of the midpoint rule.
-    pub fn iter(&self) -> core::slice::Iter<f64> {
+    pub fn iter(&self) -> core::slice::Iter<'_, f64> {
         self.nodes.iter()
     }
 

--- a/src/midpoint/mod.rs
+++ b/src/midpoint/mod.rs
@@ -74,11 +74,13 @@ impl Midpoint {
     }
 
     /// Returns an iterator over the nodes of the midpoint rule.
+    #[inline]
     pub fn iter(&self) -> core::slice::Iter<'_, f64> {
         self.nodes.iter()
     }
 
     /// Returns the nodes of the rule as a slice.
+    #[inline]
     pub fn as_nodes(&self) -> &[f64] {
         &self.nodes
     }
@@ -86,6 +88,7 @@ impl Midpoint {
     /// Converts `self` into a vector of nodes.
     ///
     /// Simply returns the underlying vector with no computation or allocation.
+    #[inline]
     pub fn into_nodes(self) -> Vec<f64> {
         self.nodes
     }

--- a/src/midpoint/mod.rs
+++ b/src/midpoint/mod.rs
@@ -61,7 +61,7 @@ pub struct Midpoint {
 }
 
 impl Midpoint {
-    /// Initialize a new midpoint rule with `degree` number of cells.
+    /// Initialize a new midpoint rule with `degree` number of cells. The nodes are evenly spaced.
     // -- code based on Luca Palmieri's "Scientific computing: a Rust adventure [Part 2 - Array1]"
     //    <https://www.lpalmieri.com/posts/2019-04-07-scientific-computing-a-rust-adventure-part-2-array1/>
     /// # Panics
@@ -69,18 +69,25 @@ impl Midpoint {
     pub fn new(degree: usize) -> Self {
         assert!(degree >= 1, "Degree of Midpoint rule needs to be >= 1");
         Self {
-            nodes: Self::nodes(degree),
+            nodes: (0..degree).map(|d| d as f64).collect(),
         }
     }
 
-    /// Make a set of evenly spaced nodes
-    fn nodes(degree: usize) -> Vec<f64> {
-        let mut nodes = Vec::with_capacity(degree);
-        for idx in 0..degree {
-            nodes.push(idx as f64);
-        }
+    /// Returns an iterator over the nodes of the midpoint rule.
+    pub fn iter(&self) -> core::slice::Iter<f64> {
+        self.nodes.iter()
+    }
 
-        nodes
+    /// Returns the nodes of the rule as a slice.
+    pub fn as_nodes(&self) -> &[f64] {
+        &self.nodes
+    }
+
+    /// Converts `self` into a vector of nodes.
+    ///
+    /// Simply returns the underlying vector with no computation or allocation.
+    pub fn into_nodes(self) -> Vec<f64> {
+        self.nodes
     }
 
     /// Integrate over the domain [a, b].
@@ -97,6 +104,14 @@ impl Midpoint {
             .sum();
 
         sum * rect_width
+    }
+}
+
+impl IntoIterator for Midpoint {
+    type IntoIter = std::vec::IntoIter<f64>;
+    type Item = f64;
+    fn into_iter(self) -> Self::IntoIter {
+        self.nodes.into_iter()
     }
 }
 

--- a/src/midpoint/mod.rs
+++ b/src/midpoint/mod.rs
@@ -40,6 +40,8 @@
 //! assert_abs_diff_eq!(0.135257, piecewise, epsilon = eps);
 //! ```
 
+use crate::Node;
+
 /// A midpoint rule quadrature scheme.
 /// ```
 /// # extern crate gauss_quad;
@@ -57,7 +59,7 @@
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Midpoint {
     /// The dimensionless midpoints
-    nodes: Vec<f64>,
+    nodes: Vec<Node>,
 }
 
 impl Midpoint {
@@ -75,13 +77,13 @@ impl Midpoint {
 
     /// Returns an iterator over the nodes of the midpoint rule.
     #[inline]
-    pub fn iter(&self) -> core::slice::Iter<'_, f64> {
+    pub fn iter(&self) -> core::slice::Iter<'_, Node> {
         self.nodes.iter()
     }
 
     /// Returns the nodes of the rule as a slice.
     #[inline]
-    pub fn as_nodes(&self) -> &[f64] {
+    pub fn as_nodes(&self) -> &[Node] {
         &self.nodes
     }
 
@@ -89,7 +91,7 @@ impl Midpoint {
     ///
     /// Simply returns the underlying vector with no computation or allocation.
     #[inline]
-    pub fn into_nodes(self) -> Vec<f64> {
+    pub fn into_nodes(self) -> Vec<Node> {
         self.nodes
     }
 
@@ -111,8 +113,8 @@ impl Midpoint {
 }
 
 impl IntoIterator for Midpoint {
-    type IntoIter = std::vec::IntoIter<f64>;
-    type Item = f64;
+    type IntoIter = std::vec::IntoIter<Node>;
+    type Item = Node;
     fn into_iter(self) -> Self::IntoIter {
         self.nodes.into_iter()
     }

--- a/src/midpoint/mod.rs
+++ b/src/midpoint/mod.rs
@@ -40,7 +40,10 @@
 //! assert_abs_diff_eq!(0.135257, piecewise, epsilon = eps);
 //! ```
 
+pub mod iterators;
+
 use crate::Node;
+use iterators::MidpointIter;
 
 /// A midpoint rule quadrature scheme.
 /// ```
@@ -77,8 +80,8 @@ impl Midpoint {
 
     /// Returns an iterator over the nodes of the midpoint rule.
     #[inline]
-    pub fn iter(&self) -> core::slice::Iter<'_, Node> {
-        self.nodes.iter()
+    pub fn iter(&self) -> MidpointIter<'_> {
+        MidpointIter::new(self.nodes.iter())
     }
 
     /// Returns the nodes of the rule as a slice.

--- a/src/simpson/iterators.rs
+++ b/src/simpson/iterators.rs
@@ -1,0 +1,47 @@
+//! This crate contains the implementation of the iterators that
+//! can be returned by method calls on a [`Simpson`](super::Simpson) instance.
+
+use crate::Node;
+use core::{iter::FusedIterator, slice::Iter};
+
+/// An iterator of the nodes of a [`Simpson`](super::Simpson) instance.
+/// Created by the [`Simpson::iter`](super::Simpson::iter) function, see it for more information.
+#[must_use = "iterators are lazy and do nothing unless consumed"]
+#[derive(Debug, Clone)]
+pub struct SimpsonIter<'a>(Iter<'a, Node>);
+
+impl<'a> SimpsonIter<'a> {
+    #[inline]
+    pub(super) fn new(iter: Iter<'a, Node>) -> Self {
+        Self(iter)
+    }
+
+    /// Views the underlying data as a subslice of the original data.
+    ///
+    /// See [`core::slice::Iter::as_slice`] for more information.
+    #[inline]
+    pub fn as_slice(&self) -> &'a [Node] {
+        self.0.as_slice()
+    }
+}
+
+impl<'a> Iterator for SimpsonIter<'a> {
+    type Item = &'a Node;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+impl<'a> DoubleEndedIterator for SimpsonIter<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.0.next_back()
+    }
+}
+
+impl<'a> ExactSizeIterator for SimpsonIter<'a> {}
+impl<'a> FusedIterator for SimpsonIter<'a> {}

--- a/src/simpson/mod.rs
+++ b/src/simpson/mod.rs
@@ -45,27 +45,38 @@
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Simpson {
-    /// The dimensionless Simpsons
+    /// The dimensionless Simpsons nodes.
     nodes: Vec<f64>,
 }
 
 impl Simpson {
-    /// Initialize a new Simpson rule with `degree` being the number of intervals
+    /// Initialize a new Simpson rule with `degree` being the number of intervals.
     pub fn new(degree: usize) -> Self {
         assert!(degree >= 1, "Degree of Simpson rule needs to be >= 1");
+        
         Self {
-            nodes: Self::nodes(degree),
+            nodes: (0..degree).map(|d| d as f64).collect(),
         }
     }
 
-    /// Generate vector of indices for the subintervals
-    fn nodes(degree: usize) -> Vec<f64> {
-        let mut nodes = Vec::with_capacity(degree);
-        for idx in 0..degree {
-            nodes.push(idx as f64);
-        }
+    /// Returns an iterator over the nodes of the rule.
+    #[inline]
+    pub fn iter(&self) -> core::slice::Iter<'_, f64> {
+        self.nodes.iter()
+    }
 
-        nodes
+    /// Returns a slice of all the nodes of the rule.
+    #[inline]
+    pub fn as_nodes(&self) -> &[f64] {
+        &self.nodes
+    }
+
+    /// Converts `self` into a vector of nodes.
+    /// 
+    /// Simply returns the underlying vector without any computation or allocation.
+    #[inline]
+    pub fn into_nodes(self) -> Vec<f64> {
+        self.nodes
     }
 
     /// Integrate over the domain [a, b].
@@ -100,6 +111,14 @@ impl Simpson {
                 + 4.0 * integrand(a + (2.0 * n - 1.0) * h / 2.0)
                 + integrand(a)
                 + integrand(b))
+    }
+}
+
+impl IntoIterator for Simpson {
+    type IntoIter = std::vec::IntoIter<f64>;
+    type Item = f64;
+    fn into_iter(self) -> Self::IntoIter {
+        self.nodes.into_iter()
     }
 }
 

--- a/src/simpson/mod.rs
+++ b/src/simpson/mod.rs
@@ -33,6 +33,8 @@
 //!
 //! ```
 
+use crate::Node;
+
 /// A Simpson rule quadrature scheme.
 /// ```
 /// # use gauss_quad::Simpson;
@@ -46,7 +48,7 @@
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Simpson {
     /// The dimensionless Simpsons nodes.
-    nodes: Vec<f64>,
+    nodes: Vec<Node>,
 }
 
 impl Simpson {
@@ -61,13 +63,13 @@ impl Simpson {
 
     /// Returns an iterator over the nodes of the rule.
     #[inline]
-    pub fn iter(&self) -> core::slice::Iter<'_, f64> {
+    pub fn iter(&self) -> core::slice::Iter<'_, Node> {
         self.nodes.iter()
     }
 
     /// Returns a slice of all the nodes of the rule.
     #[inline]
-    pub fn as_nodes(&self) -> &[f64] {
+    pub fn as_nodes(&self) -> &[Node] {
         &self.nodes
     }
 
@@ -75,7 +77,7 @@ impl Simpson {
     ///
     /// Simply returns the underlying vector without any computation or allocation.
     #[inline]
-    pub fn into_nodes(self) -> Vec<f64> {
+    pub fn into_nodes(self) -> Vec<Node> {
         self.nodes
     }
 
@@ -115,8 +117,8 @@ impl Simpson {
 }
 
 impl IntoIterator for Simpson {
-    type IntoIter = std::vec::IntoIter<f64>;
-    type Item = f64;
+    type IntoIter = std::vec::IntoIter<Node>;
+    type Item = Node;
     fn into_iter(self) -> Self::IntoIter {
         self.nodes.into_iter()
     }

--- a/src/simpson/mod.rs
+++ b/src/simpson/mod.rs
@@ -53,7 +53,7 @@ impl Simpson {
     /// Initialize a new Simpson rule with `degree` being the number of intervals.
     pub fn new(degree: usize) -> Self {
         assert!(degree >= 1, "Degree of Simpson rule needs to be >= 1");
-        
+
         Self {
             nodes: (0..degree).map(|d| d as f64).collect(),
         }
@@ -72,7 +72,7 @@ impl Simpson {
     }
 
     /// Converts `self` into a vector of nodes.
-    /// 
+    ///
     /// Simply returns the underlying vector without any computation or allocation.
     #[inline]
     pub fn into_nodes(self) -> Vec<f64> {

--- a/src/simpson/mod.rs
+++ b/src/simpson/mod.rs
@@ -33,7 +33,10 @@
 //!
 //! ```
 
+pub mod iterators;
+
 use crate::Node;
+use iterators::SimpsonIter;
 
 /// A Simpson rule quadrature scheme.
 /// ```
@@ -63,8 +66,8 @@ impl Simpson {
 
     /// Returns an iterator over the nodes of the rule.
     #[inline]
-    pub fn iter(&self) -> core::slice::Iter<'_, Node> {
-        self.nodes.iter()
+    pub fn iter(&self) -> SimpsonIter<'_> {
+        SimpsonIter::new(self.nodes.iter())
     }
 
     /// Returns a slice of all the nodes of the rule.


### PR DESCRIPTION
This is my attempt at unifying the memory and using a macro to define the API to avoid a lot of typing.

I made two macros, the first takes in a struct with a `nodes_and_weights: Vec<(f64, f64)>` field, as well as names for some iterators and defines the functions

```rust
pub fn nodes(&self) -> QuadratureRuleNodes<'_> {...}
pub fn weights(&self) -> QuadratureRuleWeights<'_> {...}
pub fn iter(&self) -> QuadratureRuleIter<'_> {...}
pub fn as_node_weight_pairs(&self) -> &[(Node, Weight)] {...}
pub fn into_node_weight_pairs(self) -> Vec<(Node, Weight)> {...}
pub fn degree(&self) -> usize {...}
```
and the second defines those iterators as well as implements the `IntoIterator` trait on the struct.

To implement the API for a rule you just call the first macro in the same file as the struct is defined and the second macro somewhere it makes sense for the iterators to be defined. I did that in sub-modules for the different rule modules.

I am not sure I implemented the constructors for the non-Legendre rules well though.

This isn't necessarily a good idea since macros are not intuitive to debug.