### PR TITLE
Merge the multiplication by the scale factor into the map call

### DIFF
--- a/src/hermite/mod.rs
+++ b/src/hermite/mod.rs
@@ -75,7 +75,10 @@ impl GaussHermite {
                 .iter()
                 .copied()
                 .zip(
-                    (eigen.eigenvectors.row(0).map(|x| x * x) * PI.sqrt())
+                    eigen
+                        .eigenvectors
+                        .row(0)
+                        .map(|x| x * x * PI.sqrt())
                         .iter()
                         .copied(),
                 )

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -103,7 +103,10 @@ impl GaussJacobi {
             .iter()
             .copied()
             .zip(
-                (eigen.eigenvectors.row(0).map(|x| x * x) * scale_factor)
+                eigen
+                    .eigenvectors
+                    .row(0)
+                    .map(|x| x * x * scale_factor)
                     .iter()
                     .copied(),
             )


### PR DESCRIPTION
In the generation of nodes and weights for the Hermite and Jacobi quadrature rules there's a line of code that looks like
```rust
...
(eigen.eigenvectors.row(0).map(|x| x * x) * a_scalar_factor).iteration_function()
...
```
The map call results in a new matrix with each element squared, and then the matrix-scalar multiplication is most likely implemented by looping over the entire matrix and multiplying each element one by one by the scalar, so by merging this multiplication into the call to map there should be fewer loops needed and it should remove one allocation.