### PR TITLE
Implement the `AsRef<[Node]>` trait for the iterators over Midpoint or Simpson nodes

### DIFF
--- a/src/midpoint/iterators.rs
+++ b/src/midpoint/iterators.rs
@@ -26,6 +26,13 @@ impl<'a> MidpointIter<'a> {
     }
 }
 
+impl<'a> AsRef<[Node]> for MidpointIter<'a> {
+    #[inline]
+    fn as_ref(&self) -> &[Node] {
+        self.0.as_ref()
+    }
+}
+
 impl<'a> Iterator for MidpointIter<'a> {
     type Item = &'a Node;
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/simpson/iterators.rs
+++ b/src/simpson/iterators.rs
@@ -25,6 +25,13 @@ impl<'a> SimpsonIter<'a> {
     }
 }
 
+impl<'a> AsRef<[Node]> for SimpsonIter<'a> {
+    #[inline]
+    fn as_ref(&self) -> &[Node] {
+        self.0.as_ref()
+    }
+}
+
 impl<'a> Iterator for SimpsonIter<'a> {
     type Item = &'a Node;
     fn next(&mut self) -> Option<Self::Item> {


### PR DESCRIPTION
All the other iterators implement this when possible, this just makes it consistent