### PR TITLE
Fix div by zero

### DIFF
--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -109,9 +109,6 @@ impl GaussJacobi {
             )
             .collect();
 
-        // TODO: ADDED THIS PRINT ONLY FOR THE FAILING TEST, REMOVE AFTER FIXING
-        println!("{deg}, {alpha}, {beta}, {node_weight_pairs:?}");
-
         node_weight_pairs.sort_unstable_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
 
         // TO FIX: implement correction
@@ -173,15 +170,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn found_nans() {
-        _ = GaussJacobi::new(10, -0.5, -0.5);
-    }
-
-    #[test]
-    fn found_nans_2() {
-        // This should succeed according to the documentation of GaussJacobi::new(), but
-        // line 72 divides by (2 + alpha + beta): a division by zero if alpha = beta = -1.
-        _ = GaussJacobi::new(10, -1., -1.);
+    #[should_panic]
+    fn check_alpha_beta_bounds() {
+        _ = GaussJacobi::new(10, -1.0, -1.0);
     }
 
     #[test]

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -58,7 +58,7 @@ impl GaussJacobi {
     /// See Gil, Segura, Temme - Numerical Methods for Special Functions
     ///
     /// # Panics
-    /// Panics if `degree` is smaller than 2, or if `alpha` or `beta` are smaller than or equal to -1.
+    /// Panics if `deg` is smaller than 2, or if `alpha` or `beta` are smaller than or equal to -1.
     pub fn new(deg: usize, alpha: f64, beta: f64) -> GaussJacobi {
         if alpha <= -1.0 || beta <= -1.0 {
             panic!("Gauss-Jacobi quadrature needs alpha > -1.0 and beta > -1.0");

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -178,6 +178,13 @@ mod tests {
     }
 
     #[test]
+    fn found_nans_2() {
+        // This should succeed according to the documentation of GaussJacobi::new(), but
+        // line 72 divides by (2 + alpha + beta): a division by zero if alpha = beta = -1.
+        _ = GaussJacobi::new(10, -1., -1.);
+    }
+
+    #[test]
     fn golub_welsch_5_alpha_0_beta_0() {
         let (x, w): (Vec<_>, Vec<_>) = GaussJacobi::new(5, 0.0, 0.0).into_iter().unzip();
         let x_should = [

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -58,9 +58,9 @@ impl GaussJacobi {
     /// See Gil, Segura, Temme - Numerical Methods for Special Functions
     ///
     /// # Panics
-    /// Panics if degree of quadrature is smaller than 2, or if alpha or beta are smaller than -1
+    /// Panics if `degree` is smaller than 2, or if `alpha` or `beta` are smaller than or equal to -1.
     pub fn new(deg: usize, alpha: f64, beta: f64) -> GaussJacobi {
-        if alpha < -1.0 || beta < -1.0 {
+        if alpha <= -1.0 || beta <= -1.0 {
             panic!("Gauss-Jacobi quadrature needs alpha > -1.0 and beta > -1.0");
         }
         if deg < 2 {

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -108,6 +108,10 @@ impl GaussJacobi {
                     .copied(),
             )
             .collect();
+
+        // TODO: ADDED THIS PRINT ONLY FOR THE FAILING TEST, REMOVE AFTER FIXING
+        println!("{deg}, {alpha}, {beta}, {node_weight_pairs:?}");
+
         node_weight_pairs.sort_unstable_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
 
         // TO FIX: implement correction
@@ -167,6 +171,12 @@ impl_data_api! {GaussJacobi, GaussJacobiNodes, GaussJacobiWeights, GaussJacobiIt
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn found_nans() {
+        _ = GaussJacobi::new(10, -0.5, -0.5);
+    }
+
     #[test]
     fn golub_welsch_5_alpha_0_beta_0() {
         let (x, w): (Vec<_>, Vec<_>) = GaussJacobi::new(5, 0.0, 0.0).into_iter().unzip();


### PR DESCRIPTION
This removes a potential division by zero in `GaussJacobi::new` by panicking if `alpha <= -1 || beta <= -1` instead of `alpha < -1  || beta < -1`.