### PR TITLE
Data api macro tweaks

### DIFF
--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -446,7 +446,7 @@ macro_rules! impl_node_rule_iterators {
             }
         }
 
-        impl<'a> ::core::convert::AsRef<[$crate::Node]> for $quadrature_rule_into_iter {
+        impl ::core::convert::AsRef<[$crate::Node]> for $quadrature_rule_into_iter {
             #[inline]
             fn as_ref(&self) -> &[$crate::Node] {
                 self.0.as_ref()

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -283,8 +283,6 @@ macro_rules! impl_node_weight_rule_iterators {
             }
         }
 
-        $crate::impl_slice_iterator_newtype_traits!{$quadrature_rule_iter<'a>, &'a ($crate::Node, $crate::Weight)}
-
         impl<'a> ::core::convert::AsRef<[($crate::Node, $crate::Weight)]>
             for $quadrature_rule_iter<'a>
         {
@@ -293,6 +291,8 @@ macro_rules! impl_node_weight_rule_iterators {
                 self.0.as_ref()
             }
         }
+
+        $crate::impl_slice_iterator_newtype_traits!{$quadrature_rule_iter<'a>, &'a ($crate::Node, $crate::Weight)}
 
         // endregion: QuadratureRuleIter
 
@@ -304,8 +304,6 @@ macro_rules! impl_node_weight_rule_iterators {
         #[derive(::core::fmt::Debug, ::core::clone::Clone)]
         #[must_use = "iterators are lazy and do nothing unless consumed"]
         pub struct $quadrature_rule_into_iter(::std::vec::IntoIter<($crate::Node, $crate::Weight)>);
-
-        $crate::impl_slice_iterator_newtype_traits!{$quadrature_rule_into_iter, ($crate::Node, $crate::Weight)}
 
         impl $quadrature_rule_into_iter {
             #[inline]
@@ -332,6 +330,8 @@ macro_rules! impl_node_weight_rule_iterators {
                 self.0.as_ref()
             }
         }
+
+        $crate::impl_slice_iterator_newtype_traits!{$quadrature_rule_into_iter, ($crate::Node, $crate::Weight)}
 
         // endregion: QuadratureRuleIntoIter
     };
@@ -446,14 +446,14 @@ macro_rules! impl_node_rule_iterators {
             }
         }
 
-        $crate::impl_slice_iterator_newtype_traits! {$quadrature_rule_into_iter, $crate::Node}
-
         impl<'a> ::core::convert::AsRef<[$crate::Node]> for $quadrature_rule_into_iter {
             #[inline]
             fn as_ref(&self) -> &[$crate::Node] {
                 self.0.as_ref()
             }
         }
+
+        $crate::impl_slice_iterator_newtype_traits! {$quadrature_rule_into_iter, $crate::Node}
 
         // endregion: QuadratureRuleIntoIter
     };

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -395,7 +395,7 @@ macro_rules! impl_node_weight_rule_iterators {
 }
 
 /// This macro implements the functions of the [`NodeRule`] trait for
-/// the given quadrature struct that contans a field named `nodes`
+/// the given rule struct that contans a field named `nodes`
 /// of the type `Vec<Node>`. It takes the name of the rule struct as well as the name
 /// of the iterator over its nodes.
 #[macro_export]

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -96,11 +96,23 @@ macro_rules! impl_node_weight_rule_trait {
         $quadrature_rule_weights:ident,
         // The name that the iterator returned when calling the `iter` function should have,
         // e.g. GaussLegendreIter.
-        $quadrature_rule_iter:ident
+        $quadrature_rule_iter:ident,
+        // The name of the iterator returned by the by the IntoIterator trait.
+        $quadrature_rule_into_iter:ident
     ) => {
         // Implements functions for accessing the underlying data of the quadrature rule struct
         // in a way the adheres to the API guidelines: <https://rust-lang.github.io/api-guidelines/naming.html>.
-        // The functions in this impl block all have an #[inline] directive because they are trivial.
+        // The functions in these impl blocks all have an #[inline] directive because they are trivial.
+
+        impl ::core::iter::IntoIterator for $quadrature_rule {
+            type IntoIter = $quadrature_rule_into_iter;
+            type Item = ($crate::Node, $crate::Weight);
+            #[inline]
+            fn into_iter(self) -> Self::IntoIter {
+                $quadrature_rule_into_iter::new(self.node_weight_pairs.into_iter())
+            }
+        }
+
         impl $crate::NodeWeightRule for $quadrature_rule {
             type Node = f64;
             type Weight = f64;
@@ -377,15 +389,6 @@ macro_rules! impl_node_weight_rule_iterators {
             #[inline]
             fn as_ref(&self) -> &[($crate::Node, $crate::Weight)] {
                 self.0.as_ref()
-            }
-        }
-
-        impl ::core::iter::IntoIterator for $quadrature_rule {
-            type IntoIter = $quadrature_rule_into_iter;
-            type Item = ($crate::Node, $crate::Weight);
-            #[inline]
-            fn into_iter(self) -> Self::IntoIter {
-                $quadrature_rule_into_iter::new(self.node_weight_pairs.into_iter())
             }
         }
 

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -1,10 +1,8 @@
 //! This module contains the traits [`NodeRule`] and [`NodeWeightRule`] as well as
 //! macros that can be used to implement them.
 //! The traits define the common API for accessing the data that underlies the quadrature rules.
-//! The [`impl_node_weight_rule_trait!`] macro implements the [`NodeWeightRule`] trait for a struct. It takes in the name of
-//! a quadrature rule struct that has a field named `node_weight_pairs`
-//! of the type `Vec<(Node, Weight)>`. It also needs the names that it should give the various structs
-//! that iterate over that data. It should be called in the module that defines the quadrature rule struct.
+//! The [`impl_node_weight_rule_trait!`] macro implements the [`NodeWeightRule`] trait for a struct.
+//! It should be called in the module that defines the quadrature rule struct.
 //! The [`impl_node_weight_rule_iterators!`] macro defines the iterators that the trait returns. It should be called somewhere it makes sense
 //! for the iterators to be defined, e.g. a sub-module.
 //! The [`impl_node_rule_trait!`] and [`impl_node_rule_iterators!`] do the same thing as the previous macros but for the [`NodeRule`] trait.

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -109,6 +109,7 @@ macro_rules! impl_node_weight_rule_trait {
             type Nodes<'a> = $quadrature_rule_nodes<'a>;
             type Weights<'a> = $quadrature_rule_weights<'a>;
             type Iter<'a> = $quadrature_rule_iter<'a>;
+
             #[inline]
             fn nodes(&self) -> Self::Nodes<'_> {
                 $quadrature_rule_nodes::new(self.node_weight_pairs.iter().map(|p| &p.0))
@@ -405,6 +406,7 @@ macro_rules! impl_node_rule_trait {
         impl $crate::NodeRule for $quadrature_rule {
             type Node = $crate::Node;
             type Iter<'a> = $quadrature_rule_iter<'a>;
+
             #[inline]
             fn iter(&self) -> Self::Iter<'_> {
                 $quadrature_rule_iter::new(self.nodes.iter())
@@ -414,6 +416,7 @@ macro_rules! impl_node_rule_trait {
             fn as_nodes(&self) -> &[Self::Node] {
                 &self.nodes
             }
+
             #[inline]
             fn into_nodes(self) -> Vec<Self::Node> {
                 self.nodes

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -451,7 +451,7 @@ macro_rules! impl_node_rule_iterators {
             }
         }
 
-        impl<'a> AsRef<[$crate::Node]> for $quadrature_rule_iter<'a> {
+        impl<'a> ::core::convert::AsRef<[$crate::Node]> for $quadrature_rule_iter<'a> {
             #[inline]
             fn as_ref(&self) -> &[$crate::Node] {
                 self.0.as_ref()
@@ -465,7 +465,7 @@ macro_rules! impl_node_rule_iterators {
             }
 
             #[inline]
-            fn size_hint(&self) -> (::core::primitive::usize, Option<::core::primitive::usize>) {
+            fn size_hint(&self) -> (::core::primitive::usize, ::core::option::Option<::core::primitive::usize>) {
                 self.0.size_hint()
             }
         }

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -155,7 +155,8 @@ macro_rules! impl_node_weight_rule_trait {
 }
 
 /// Implements the Iterator, DoubleEndedIterator, ExactSizeIterator and FusedIterator traits for a type
-/// that wraps an iterator that has those traits.
+/// that wraps an iterator that has those traits. Takes in the name of the struct and optionally its lifetime
+/// as well as the type returned by the iterator.
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_slice_iterator_newtype_traits {

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -154,6 +154,35 @@ macro_rules! impl_node_weight_rule_trait {
     };
 }
 
+/// Implements the Iterator, DoubleEndedIterator, ExactSizeIterator and FusedIterator traits for a type
+/// that wraps an iterator that has those traits.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! impl_slice_iterator_newtype_traits {
+    ($iterator:ident$(<$a:lifetime>)?, $item:ty) => {
+        impl<$($a)*> ::core::iter::Iterator for $iterator<$($a)*> {
+            type Item = $item;
+            fn next(&mut self) -> ::core::option::Option<Self::Item> {
+                self.0.next()
+            }
+
+            #[inline]
+            fn size_hint(&self) -> (::core::primitive::usize, ::core::option::Option<::core::primitive::usize>) {
+                self.0.size_hint()
+            }
+        }
+
+        impl<$($a)*> ::core::iter::DoubleEndedIterator for $iterator<$($a)*> {
+            fn next_back(&mut self) -> ::core::option::Option<Self::Item> {
+                self.0.next_back()
+            }
+        }
+
+        impl<$($a)*> ::core::iter::ExactSizeIterator for $iterator<$($a)*> {}
+        impl<$($a)*> ::core::iter::FusedIterator for $iterator<$($a)*> {}
+    };
+}
+
 /// This macro defines the iterators used by the functions defined in the [`impl_node_weight_rule_trait!`] macro.
 /// It takes in the names of the same structs as that macro,
 /// plus the name it should give the iterator that is returned by the [`IntoIterator`] implementation.
@@ -194,31 +223,7 @@ macro_rules! impl_node_weight_rule_iterators {
             }
         }
 
-        impl<'a> ::core::iter::Iterator for $quadrature_rule_nodes<'a> {
-            type Item = &'a $crate::Node;
-            fn next(&mut self) -> ::core::option::Option<Self::Item> {
-                self.0.next()
-            }
-
-            #[inline]
-            fn size_hint(
-                &self,
-            ) -> (
-                ::core::primitive::usize,
-                ::core::option::Option<::core::primitive::usize>,
-            ) {
-                self.0.size_hint()
-            }
-        }
-
-        impl<'a> ::core::iter::DoubleEndedIterator for $quadrature_rule_nodes<'a> {
-            fn next_back(&mut self) -> ::core::option::Option<Self::Item> {
-                self.0.next_back()
-            }
-        }
-
-        impl<'a> ::core::iter::ExactSizeIterator for $quadrature_rule_nodes<'a> {}
-        impl<'a> ::core::iter::FusedIterator for $quadrature_rule_nodes<'a> {}
+        $crate::impl_slice_iterator_newtype_traits!{$quadrature_rule_nodes<'a>, &'a $crate::Node}
 
         // endregion: QuadratureRuleNodes
 
@@ -246,31 +251,7 @@ macro_rules! impl_node_weight_rule_iterators {
             }
         }
 
-        impl<'a> ::core::iter::Iterator for $quadrature_rule_weights<'a> {
-            type Item = &'a $crate::Weight;
-            fn next(&mut self) -> ::core::option::Option<Self::Item> {
-                self.0.next()
-            }
-
-            #[inline]
-            fn size_hint(
-                &self,
-            ) -> (
-                ::core::primitive::usize,
-                ::core::option::Option<::core::primitive::usize>,
-            ) {
-                self.0.size_hint()
-            }
-        }
-
-        impl<'a> ::core::iter::DoubleEndedIterator for $quadrature_rule_weights<'a> {
-            fn next_back(&mut self) -> ::core::option::Option<Self::Item> {
-                self.0.next_back()
-            }
-        }
-
-        impl<'a> ::core::iter::ExactSizeIterator for $quadrature_rule_weights<'a> {}
-        impl<'a> ::core::iter::FusedIterator for $quadrature_rule_weights<'a> {}
+        $crate::impl_slice_iterator_newtype_traits!{$quadrature_rule_weights<'a>, &'a $crate::Weight}
 
         // endregion: QuadratureRuleWeights
 
@@ -302,22 +283,7 @@ macro_rules! impl_node_weight_rule_iterators {
             }
         }
 
-        impl<'a> ::core::iter::Iterator for $quadrature_rule_iter<'a> {
-            /// Element `.0` is the node and element `.1` the corresponding weight.
-            type Item = &'a ($crate::Node, $crate::Weight);
-            fn next(&mut self) -> ::core::option::Option<Self::Item> {
-                self.0.next()
-            }
-        }
-
-        impl<'a> ::core::iter::DoubleEndedIterator for $quadrature_rule_iter<'a> {
-            fn next_back(&mut self) -> ::core::option::Option<Self::Item> {
-                self.0.next_back()
-            }
-        }
-
-        impl<'a> ::core::iter::ExactSizeIterator for $quadrature_rule_iter<'a> {}
-        impl<'a> ::core::iter::FusedIterator for $quadrature_rule_iter<'a> {}
+        $crate::impl_slice_iterator_newtype_traits!{$quadrature_rule_iter<'a>, &'a ($crate::Node, $crate::Weight)}
 
         impl<'a> ::core::convert::AsRef<[($crate::Node, $crate::Weight)]>
             for $quadrature_rule_iter<'a>
@@ -339,32 +305,7 @@ macro_rules! impl_node_weight_rule_iterators {
         #[must_use = "iterators are lazy and do nothing unless consumed"]
         pub struct $quadrature_rule_into_iter(::std::vec::IntoIter<($crate::Node, $crate::Weight)>);
 
-        impl ::core::iter::Iterator for $quadrature_rule_into_iter {
-            /// Element `.0` is the node and element `.1` the corresponding weight.
-            type Item = ($crate::Node, $crate::Weight);
-            fn next(&mut self) -> ::core::option::Option<Self::Item> {
-                self.0.next()
-            }
-
-            #[inline]
-            fn size_hint(
-                &self,
-            ) -> (
-                ::core::primitive::usize,
-                ::core::option::Option<::core::primitive::usize>,
-            ) {
-                self.0.size_hint()
-            }
-        }
-
-        impl ::core::iter::DoubleEndedIterator for $quadrature_rule_into_iter {
-            fn next_back(&mut self) -> ::core::option::Option<Self::Item> {
-                self.0.next_back()
-            }
-        }
-
-        impl ::core::iter::ExactSizeIterator for $quadrature_rule_into_iter {}
-        impl ::core::iter::FusedIterator for $quadrature_rule_into_iter {}
+        $crate::impl_slice_iterator_newtype_traits!{$quadrature_rule_into_iter, ($crate::Node, $crate::Weight)}
 
         impl $quadrature_rule_into_iter {
             #[inline]
@@ -477,31 +418,7 @@ macro_rules! impl_node_rule_iterators {
             }
         }
 
-        impl<'a> Iterator for $quadrature_rule_iter<'a> {
-            type Item = &'a $crate::Node;
-            fn next(&mut self) -> ::core::option::Option<Self::Item> {
-                self.0.next()
-            }
-
-            #[inline]
-            fn size_hint(
-                &self,
-            ) -> (
-                ::core::primitive::usize,
-                ::core::option::Option<::core::primitive::usize>,
-            ) {
-                self.0.size_hint()
-            }
-        }
-
-        impl<'a> ::core::iter::DoubleEndedIterator for $quadrature_rule_iter<'a> {
-            fn next_back(&mut self) -> ::core::option::Option<Self::Item> {
-                self.0.next_back()
-            }
-        }
-
-        impl<'a> ::core::iter::ExactSizeIterator for $quadrature_rule_iter<'a> {}
-        impl<'a> ::core::iter::FusedIterator for $quadrature_rule_iter<'a> {}
+        $crate::impl_slice_iterator_newtype_traits! {$quadrature_rule_iter<'a>, &'a $crate::Node}
 
         // endregion: QuadratureRuleIter
 
@@ -529,31 +446,7 @@ macro_rules! impl_node_rule_iterators {
             }
         }
 
-        impl ::core::iter::Iterator for $quadrature_rule_into_iter {
-            type Item = $crate::Node;
-            fn next(&mut self) -> ::core::option::Option<Self::Item> {
-                self.0.next()
-            }
-
-            #[inline]
-            fn size_hint(
-                &self,
-            ) -> (
-                ::core::primitive::usize,
-                ::core::option::Option<::core::primitive::usize>,
-            ) {
-                self.0.size_hint()
-            }
-        }
-
-        impl ::core::iter::DoubleEndedIterator for $quadrature_rule_into_iter {
-            fn next_back(&mut self) -> ::core::option::Option<Self::Item> {
-                self.0.next_back()
-            }
-        }
-
-        impl ::core::iter::ExactSizeIterator for $quadrature_rule_into_iter {}
-        impl ::core::iter::FusedIterator for $quadrature_rule_into_iter {}
+        $crate::impl_slice_iterator_newtype_traits! {$quadrature_rule_into_iter, $crate::Node}
 
         impl<'a> ::core::convert::AsRef<[$crate::Node]> for $quadrature_rule_into_iter {
             #[inline]

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -83,7 +83,7 @@ where
 /// This macro implements the functions of the [`NodeWeightRule`] trait for the given quadrature rule struct that contains
 /// a field named `node_weight_pairs` of the type `Vec<Node, Weight>`.
 /// It takes in the name of the quadrature rule struct as well as the names if should give the iterators
-/// over its nodes, weights, and both.
+/// over its nodes, weights, and both, as well as the iterator returned by the [`IntoIterator`] trait.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! impl_node_weight_rule_trait {
@@ -196,7 +196,6 @@ macro_rules! impl_node_weight_rule_iterators {
         $quadrature_rule_nodes:ident,
         $quadrature_rule_weights:ident,
         $quadrature_rule_iter:ident,
-        // The name of the iterator that should be returned by the IntoIterator trait.
         $quadrature_rule_into_iter:ident
     ) => {
         // region: QuadratureRuleNodes
@@ -340,7 +339,7 @@ macro_rules! impl_node_weight_rule_iterators {
 /// This macro implements the functions of the [`NodeRule`] trait for
 /// the given rule struct that contans a field named `nodes`
 /// of the type `Vec<Node>`. It takes the name of the rule struct as well as the name
-/// it should give the iterator over its nodes.
+/// it should give the iterator over its nodes and the iterator returned by the [`IntoIterator`] trait.
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_node_rule_trait {

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -1,7 +1,7 @@
 //! This module contains the traits [`NodeRule`] and [`NodeWeightRule`] as well as
 //! two macros: [`impl_data_api!`] and [`impl_iterators!`].
 //! The traits define the common API for accessing the data that underlies the quadrature rules.
-//! The first macro implements the [`NodeWeightRule`] trait for a struct. It takes in the name of 
+//! The first macro implements the [`NodeWeightRule`] trait for a struct. It takes in the name of
 //! a quadrature rule struct that has a field named `node_weight_pairs`
 //! of the type `Vec<(Node, Weight)>`. It also needs the names that it should give the various structs
 //! that iterate over that data. It should be called in the module that defines the quadrature rule struct.
@@ -86,7 +86,7 @@ where
 /// over its nodes, weights, and both.
 #[doc(hidden)]
 #[macro_export]
-macro_rules! impl_data_api {
+macro_rules! impl_node_weight_rule_trait {
     (
         // The name of the quadrature rule struct, e.g. GaussLegendre.
         $quadrature_rule:ident,

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -29,44 +29,40 @@ macro_rules! impl_data_api {
         // Implements functions for accessing the underlying data of the quadrature rule struct
         // in a way the adheres to the API guidelines: <https://rust-lang.github.io/api-guidelines/naming.html>.
         // The functions in this impl block all have an #[inline] directive because they are trivial.
-        impl $quadrature_rule {
-            /// Returns an iterator over the nodes of the quadrature rule.
+        impl $crate::NodeWeightRule for $quadrature_rule {
+            type Node = f64;
+            type Weight = f64;
+            type Nodes<'a> = $quadrature_rule_nodes<'a>;
+            type Weights<'a> = $quadrature_rule_weights<'a>;
+            type Iter<'a> = $quadrature_rule_iter<'a>;
             #[inline]
-            pub fn nodes(&self) -> $quadrature_rule_nodes<'_> {
+            fn nodes(&self) -> Self::Nodes<'_> {
                 $quadrature_rule_nodes::new(self.node_weight_pairs.iter().map(|p| &p.0))
             }
 
-            /// Returns an iterator over the weights of the quadrature rule.
             #[inline]
-            pub fn weights(&self) -> $quadrature_rule_weights<'_> {
+            fn weights(&self) -> Self::Weights<'_> {
                 $quadrature_rule_weights::new(self.node_weight_pairs.iter().map(|p| &p.1))
             }
 
-            /// Returns an iterator over the node-weight-pairs of the quadrature rule.
             #[inline]
-            pub fn iter(&self) -> $quadrature_rule_iter<'_> {
+            fn iter(&self) -> Self::Iter<'_> {
                 $quadrature_rule_iter::new(self.node_weight_pairs.iter())
             }
 
-            /// Returns a slice of the node-weight-pairs of the quadrature rule.
             #[inline]
-            pub fn as_node_weight_pairs(&self) -> &[(Node, Weight)] {
+            fn as_node_weight_pairs(&self) -> &[(Self::Node, Self::Weight)] {
                 &self.node_weight_pairs
             }
 
-            /// Converts the quadrature rule into a vector of node-weight-pairs.
-            ///
-            /// This function just returns the underlying data and does no
-            /// computation or cloning.
             #[inline]
             #[must_use = "`self` will be dropped if the result is not used"]
-            pub fn into_node_weight_pairs(self) -> ::std::vec::Vec<(Node, Weight)> {
+            fn into_node_weight_pairs(self) -> ::std::vec::Vec<(Self::Node, Self::Weight)> {
                 self.node_weight_pairs
             }
 
-            /// Returns the degree of the quadrature rule.
             #[inline]
-            pub fn degree(&self) -> ::core::primitive::usize {
+            fn degree(&self) -> ::core::primitive::usize {
                 self.node_weight_pairs.len()
             }
         }

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -160,7 +160,7 @@ macro_rules! impl_node_weight_rule_trait {
 #[doc(hidden)]
 macro_rules! impl_slice_iterator_newtype_traits {
     ($iterator:ident$(<$a:lifetime>)?, $item:ty) => {
-        impl<$($a)?> ::core::iter::Iterator for $iterator<$($a)?> {
+        impl$(<$a>)? ::core::iter::Iterator for $iterator<$($a)?> {
             type Item = $item;
             fn next(&mut self) -> ::core::option::Option<Self::Item> {
                 self.0.next()
@@ -172,14 +172,14 @@ macro_rules! impl_slice_iterator_newtype_traits {
             }
         }
 
-        impl<$($a)?> ::core::iter::DoubleEndedIterator for $iterator<$($a)?> {
+        impl$(<$a>)? ::core::iter::DoubleEndedIterator for $iterator$(<$a>)? {
             fn next_back(&mut self) -> ::core::option::Option<Self::Item> {
                 self.0.next_back()
             }
         }
 
-        impl<$($a)?> ::core::iter::ExactSizeIterator for $iterator<$($a)?> {}
-        impl<$($a)?> ::core::iter::FusedIterator for $iterator<$($a)?> {}
+        impl$(<$a>)? ::core::iter::ExactSizeIterator for $iterator$(<$a>)? {}
+        impl$(<$a>)? ::core::iter::FusedIterator for $iterator$(<$a>)? {}
     };
 }
 

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -322,7 +322,7 @@ macro_rules! impl_node_weight_rule_iterators {
             }
         }
 
-        impl<'a> ::core::convert::AsRef<[($crate::Node, $crate::Weight)]>
+        impl ::core::convert::AsRef<[($crate::Node, $crate::Weight)]>
             for $quadrature_rule_into_iter
         {
             #[inline]

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -142,7 +142,7 @@ macro_rules! impl_node_weight_rule_trait {
     };
 }
 
-/// This macro defines the iterators used by the functions defined in the macro [`impl_data_api!`].
+/// This macro defines the iterators used by the functions defined in the [`impl_node_weight_rule_trait!`] macro.
 /// It takes in the names of the same structs as that macro,
 /// plus the name of the iterator that should be returned by the [`IntoIterator`] implementation.
 /// These iterators can only be created in the module where the macro is called
@@ -425,6 +425,11 @@ macro_rules! impl_node_rule_trait {
     };
 }
 
+/// This macro defines the iterators used by the functions defined by the [`impl_node_rule_trait`] macro.
+/// It takes in the names of the same structs as that macro,
+/// plus the name of the iterator that should be returned by the [`IntoIterator`] implementation.
+/// These iterators can only be created in the module where the macro is called
+/// or the module above it (due to the `pub(super)` marker on the constructors).
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_node_rule_iterators {
@@ -465,7 +470,12 @@ macro_rules! impl_node_rule_iterators {
             }
 
             #[inline]
-            fn size_hint(&self) -> (::core::primitive::usize, ::core::option::Option<::core::primitive::usize>) {
+            fn size_hint(
+                &self,
+            ) -> (
+                ::core::primitive::usize,
+                ::core::option::Option<::core::primitive::usize>,
+            ) {
                 self.0.size_hint()
             }
         }

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -194,7 +194,6 @@ macro_rules! impl_slice_iterator_newtype_traits {
 #[macro_export]
 macro_rules! impl_node_weight_rule_iterators {
     (
-        $quadrature_rule:ident,
         $quadrature_rule_nodes:ident,
         $quadrature_rule_weights:ident,
         $quadrature_rule_iter:ident,
@@ -389,7 +388,7 @@ macro_rules! impl_node_rule_trait {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_node_rule_iterators {
-    ($quadrature_rule:ident, $quadrature_rule_iter:ident, $quadrature_rule_into_iter:ident) => {
+    ($quadrature_rule_iter:ident, $quadrature_rule_into_iter:ident) => {
         // region: QuadratureRuleIter
 
         /// An iterator of the nodes of the rule.

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -160,7 +160,7 @@ macro_rules! impl_node_weight_rule_trait {
 #[doc(hidden)]
 macro_rules! impl_slice_iterator_newtype_traits {
     ($iterator:ident$(<$a:lifetime>)?, $item:ty) => {
-        impl<$($a)*> ::core::iter::Iterator for $iterator<$($a)*> {
+        impl<$($a)?> ::core::iter::Iterator for $iterator<$($a)?> {
             type Item = $item;
             fn next(&mut self) -> ::core::option::Option<Self::Item> {
                 self.0.next()
@@ -172,14 +172,14 @@ macro_rules! impl_slice_iterator_newtype_traits {
             }
         }
 
-        impl<$($a)*> ::core::iter::DoubleEndedIterator for $iterator<$($a)*> {
+        impl<$($a)?> ::core::iter::DoubleEndedIterator for $iterator<$($a)?> {
             fn next_back(&mut self) -> ::core::option::Option<Self::Item> {
                 self.0.next_back()
             }
         }
 
-        impl<$($a)*> ::core::iter::ExactSizeIterator for $iterator<$($a)*> {}
-        impl<$($a)*> ::core::iter::FusedIterator for $iterator<$($a)*> {}
+        impl<$($a)?> ::core::iter::ExactSizeIterator for $iterator<$($a)?> {}
+        impl<$($a)?> ::core::iter::FusedIterator for $iterator<$($a)?> {}
     };
 }
 

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -28,7 +28,7 @@ where
     type Node;
     /// The type of the weights.
     type Weight;
-    /// An iterator over node-weight-pairs of the quadrature rule.
+    /// An iterator over the node-weight-pairs of the quadrature rule.
     type Iter<'a>: Iterator<Item = &'a (Self::Node, Self::Weight)>
     where
         Self: 'a;

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -1,7 +1,8 @@
 //! This module contains the traits [`NodeRule`] and [`NodeWeightRule`] as well as
 //! two macros: [`impl_data_api!`] and [`impl_iterators!`].
 //! The traits define the common API for accessing the data that underlies the quadrature rules.
-//! The first macro takes in the name of a quadrature rule struct that has a field named `node_weight_pairs`
+//! The first macro implements the [`NodeWeightRule`] trait for a struct. It takes in the name of 
+//! a quadrature rule struct that has a field named `node_weight_pairs`
 //! of the type `Vec<(Node, Weight)>`. It also needs the names that it should give the various structs
 //! that iterate over that data. It should be called in the module that defines the quadrature rule struct.
 //! The second macro defines the iterators that the first returns. It should be called somewhere it makes sense

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -82,7 +82,8 @@ where
     fn degree(&self) -> usize;
 }
 
-/// This macro implements the data access API for the given quadrature rule struct.
+/// This macro implements the functions of the [`NodeWeightRule`] trait for the given quadrature rule struct that contains
+/// a field named `node_weight_pairs` of the type `Vec<Node, Weight>`.
 /// It takes in the name of the quadrature rule struct as well as the names of the iterators
 /// over its nodes, weights, and both.
 #[doc(hidden)]

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -1,12 +1,13 @@
 //! This module contains the traits [`NodeRule`] and [`NodeWeightRule`] as well as
-//! two macros: [`impl_data_api!`] and [`impl_iterators!`].
+//! macros that can be used to implement them.
 //! The traits define the common API for accessing the data that underlies the quadrature rules.
-//! The first macro implements the [`NodeWeightRule`] trait for a struct. It takes in the name of
+//! The [`impl_node_weight_rule_trait!`] macro implements the [`NodeWeightRule`] trait for a struct. It takes in the name of
 //! a quadrature rule struct that has a field named `node_weight_pairs`
 //! of the type `Vec<(Node, Weight)>`. It also needs the names that it should give the various structs
 //! that iterate over that data. It should be called in the module that defines the quadrature rule struct.
-//! The second macro defines the iterators that the first returns. It should be called somewhere it makes sense
+//! The [`impl_node_weight_rule_iterators!`] macro defines the iterators that the trait returns. It should be called somewhere it makes sense
 //! for the iterators to be defined, e.g. a sub-module.
+//! The [`impl_node_rule_trait!`] and [`impl_node_rule_iterators!`] do the same thing as the previous macros but for the [`NodeRule`] trait.
 
 // The code in the macros uses fully qualified paths for every type, so it is quite verbose.
 // That is, instead of `usize` it uses `::core::primitive::usize` and so on. This makes it so that

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -429,6 +429,8 @@ macro_rules! impl_node_rule_trait {
 #[doc(hidden)]
 macro_rules! impl_node_rule_iterators {
     ($quadrature_rule:ident, $quadrature_rule_iter:ident, $quadrature_rule_into_iter:ident) => {
+        // region: QuadratureRuleIter
+
         /// An iterator of the nodes of the rule.
         #[derive(Debug, Clone)]
         #[must_use = "iterators are lazy and do nothing unless consumed"]
@@ -476,6 +478,8 @@ macro_rules! impl_node_rule_iterators {
 
         impl<'a> ::core::iter::ExactSizeIterator for $quadrature_rule_iter<'a> {}
         impl<'a> ::core::iter::FusedIterator for $quadrature_rule_iter<'a> {}
+
+        // endregion: QuadratureRuleIter
 
         // region: QuadratureRuleIntoIter
 

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -396,7 +396,8 @@ macro_rules! impl_node_weight_rule_iterators {
 
 /// This macro implements the functions of the [`NodeRule`] trait for
 /// the given quadrature struct that contans a field named `nodes`
-/// of the type `Vec<Node>`.
+/// of the type `Vec<Node>`. It takes the name of the rule struct as well as the name
+/// of the iterator over its nodes.
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_node_rule_trait {

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -82,7 +82,7 @@ where
 
 /// This macro implements the functions of the [`NodeWeightRule`] trait for the given quadrature rule struct that contains
 /// a field named `node_weight_pairs` of the type `Vec<Node, Weight>`.
-/// It takes in the name of the quadrature rule struct as well as the names of the iterators
+/// It takes in the name of the quadrature rule struct as well as the names if should give the iterators
 /// over its nodes, weights, and both.
 #[doc(hidden)]
 #[macro_export]
@@ -144,7 +144,7 @@ macro_rules! impl_node_weight_rule_trait {
 
 /// This macro defines the iterators used by the functions defined in the [`impl_node_weight_rule_trait!`] macro.
 /// It takes in the names of the same structs as that macro,
-/// plus the name of the iterator that should be returned by the [`IntoIterator`] implementation.
+/// plus the name it should give the iterator that is returned by the [`IntoIterator`] implementation.
 /// These iterators can only be created in the module where the macro is called
 /// or the module above it (due to the `pub(super)` marker on the constructors).
 #[doc(hidden)]
@@ -396,7 +396,7 @@ macro_rules! impl_node_weight_rule_iterators {
 /// This macro implements the functions of the [`NodeRule`] trait for
 /// the given rule struct that contans a field named `nodes`
 /// of the type `Vec<Node>`. It takes the name of the rule struct as well as the name
-/// of the iterator over its nodes.
+/// it should give the iterator over its nodes.
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_node_rule_trait {
@@ -430,7 +430,7 @@ macro_rules! impl_node_rule_trait {
 
 /// This macro defines the iterators used by the functions defined by the [`impl_node_rule_trait`] macro.
 /// It takes in the names of the same structs as that macro,
-/// plus the name of the iterator that should be returned by the [`IntoIterator`] implementation.
+/// plus the name it should give the iterator that is returned by the [`IntoIterator`] implementation.
 /// These iterators can only be created in the module where the macro is called
 /// or the module above it (due to the `pub(super)` marker on the constructors).
 #[macro_export]

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -400,7 +400,15 @@ macro_rules! impl_node_weight_rule_iterators {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_node_rule_trait {
-    ($quadrature_rule:ident, $quadrature_rule_iter:ident) => {
+    ($quadrature_rule:ident, $quadrature_rule_iter:ident, $quadrature_rule_into_iter:ident) => {
+        impl ::core::iter::IntoIterator for $quadrature_rule {
+            type Item = $crate::Node;
+            type IntoIter = $quadrature_rule_into_iter;
+            fn into_iter(self) -> Self::IntoIter {
+                $quadrature_rule_into_iter::new(self.nodes.into_iter())
+            }
+        }
+
         impl $crate::NodeRule for $quadrature_rule {
             type Node = $crate::Node;
             type Iter<'a> = $quadrature_rule_iter<'a>;
@@ -548,14 +556,6 @@ macro_rules! impl_node_rule_iterators {
             #[inline]
             fn as_ref(&self) -> &[$crate::Node] {
                 self.0.as_ref()
-            }
-        }
-
-        impl ::core::iter::IntoIterator for $quadrature_rule {
-            type Item = $crate::Node;
-            type IntoIter = $quadrature_rule_into_iter;
-            fn into_iter(self) -> Self::IntoIter {
-                $quadrature_rule_into_iter::new(self.nodes.into_iter())
             }
         }
 

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -20,12 +20,12 @@ pub type Weight = f64;
 /// both nodes and weights.
 pub trait NodeWeightRule
 where
-    Self: IntoIterator,
+    Self: IntoIterator<Item = (Node, Weight)>,
 {
     /// The type of the nodes.
-    type Node: Copy;
+    type Node;
     /// The type of the weights.
-    type Weight: Copy;
+    type Weight;
     /// An iterator over node-weight-pairs of the quadrature rule.
     type Iter<'a>: Iterator<Item = &'a (Self::Node, Self::Weight)>
     where
@@ -59,10 +59,10 @@ where
 /// in rules that do not have weights.
 pub trait NodeRule
 where
-    Self: IntoIterator,
+    Self: IntoIterator<Item = Node>,
 {
     /// The type of the nodes.
-    type Node: Copy;
+    type Node;
     /// An iterator over the nodes.
     type Iter<'a>: Iterator<Item = &'a Self::Node>
     where

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -3,9 +3,10 @@
 //! The traits define the common API for accessing the data that underlies the quadrature rules.
 //! The [`impl_node_weight_rule_trait!`] macro implements the [`NodeWeightRule`] trait for a struct.
 //! It should be called in the module that defines the quadrature rule struct.
-//! The [`impl_node_weight_rule_iterators!`] macro defines the iterators that the trait returns. It should be called somewhere it makes sense
-//! for the iterators to be defined, e.g. a sub-module.
-//! The [`impl_node_rule_trait!`] and [`impl_node_rule_iterators!`] do the same thing as the previous macros but for the [`NodeRule`] trait.
+//! The [`impl_node_weight_rule_iterators!`] macro defines the iterators that the trait returns.
+//! It should be called somewhere it makes sense for the iterators to be defined, e.g. a sub-module.
+//! The [`impl_node_rule_trait!`] and [`impl_node_rule_iterators!`] do the same thing as the previous
+//! macros but for the [`NodeRule`] trait.
 
 // The code in the macros uses fully qualified paths for every type, so it is quite verbose.
 // That is, instead of `usize` it uses `::core::primitive::usize` and so on. This makes it so that

--- a/src/hermite/iterators.rs
+++ b/src/hermite/iterators.rs
@@ -2,4 +2,4 @@
 
 use super::GaussHermite;
 
-crate::impl_iterators! {GaussHermite, GaussHermiteNodes, GaussHermiteWeights, GaussHermiteIter, GaussHermiteIntoIter}
+crate::impl_node_weight_rule_iterators! {GaussHermite, GaussHermiteNodes, GaussHermiteWeights, GaussHermiteIter, GaussHermiteIntoIter}

--- a/src/hermite/iterators.rs
+++ b/src/hermite/iterators.rs
@@ -1,5 +1,3 @@
 //! This module contains the iterators produced by some of the functions on [`GaussHermite`].
 
-use super::GaussHermite;
-
 crate::impl_node_weight_rule_iterators! {GaussHermite, GaussHermiteNodes, GaussHermiteWeights, GaussHermiteIter, GaussHermiteIntoIter}

--- a/src/hermite/iterators.rs
+++ b/src/hermite/iterators.rs
@@ -1,3 +1,3 @@
-//! This module contains the iterators produced by some of the functions on [`GaussHermite`].
+//! This module contains the iterators produced by some of the functions on [`GaussHermite`](super::GaussHermite).
 
 crate::impl_node_weight_rule_iterators! {GaussHermite, GaussHermiteNodes, GaussHermiteWeights, GaussHermiteIter, GaussHermiteIntoIter}

--- a/src/hermite/iterators.rs
+++ b/src/hermite/iterators.rs
@@ -1,3 +1,3 @@
 //! This module contains the iterators produced by some of the functions on [`GaussHermite`](super::GaussHermite).
 
-crate::impl_node_weight_rule_iterators! {GaussHermite, GaussHermiteNodes, GaussHermiteWeights, GaussHermiteIter, GaussHermiteIntoIter}
+crate::impl_node_weight_rule_iterators! {GaussHermiteNodes, GaussHermiteWeights, GaussHermiteIter, GaussHermiteIntoIter}

--- a/src/hermite/mod.rs
+++ b/src/hermite/mod.rs
@@ -18,7 +18,7 @@
 pub mod iterators;
 use iterators::{GaussHermiteIntoIter, GaussHermiteIter, GaussHermiteNodes, GaussHermiteWeights};
 
-use crate::{impl_node_weight_rule_trait, DMatrixf64, Node, Weight, PI};
+use crate::{impl_node_weight_rule, DMatrixf64, Node, Weight, PI};
 
 /// A Gauss-Hermite quadrature scheme.
 ///
@@ -97,7 +97,7 @@ impl GaussHermite {
     }
 }
 
-impl_node_weight_rule_trait! {GaussHermite, GaussHermiteNodes, GaussHermiteWeights, GaussHermiteIter, GaussHermiteIntoIter}
+impl_node_weight_rule! {GaussHermite, GaussHermiteNodes, GaussHermiteWeights, GaussHermiteIter, GaussHermiteIntoIter}
 
 #[cfg(test)]
 mod tests {

--- a/src/hermite/mod.rs
+++ b/src/hermite/mod.rs
@@ -16,7 +16,7 @@
 //! ```
 
 pub mod iterators;
-use iterators::{GaussHermiteIter, GaussHermiteNodes, GaussHermiteWeights};
+use iterators::{GaussHermiteIntoIter, GaussHermiteIter, GaussHermiteNodes, GaussHermiteWeights};
 
 use crate::{impl_node_weight_rule_trait, DMatrixf64, Node, Weight, PI};
 
@@ -97,7 +97,7 @@ impl GaussHermite {
     }
 }
 
-impl_node_weight_rule_trait! {GaussHermite, GaussHermiteNodes, GaussHermiteWeights, GaussHermiteIter}
+impl_node_weight_rule_trait! {GaussHermite, GaussHermiteNodes, GaussHermiteWeights, GaussHermiteIter, GaussHermiteIntoIter}
 
 #[cfg(test)]
 mod tests {

--- a/src/hermite/mod.rs
+++ b/src/hermite/mod.rs
@@ -18,7 +18,7 @@
 pub mod iterators;
 use iterators::{GaussHermiteIter, GaussHermiteNodes, GaussHermiteWeights};
 
-use crate::{impl_data_api, DMatrixf64, Node, Weight, PI};
+use crate::{impl_node_weight_rule_trait, DMatrixf64, Node, Weight, PI};
 
 /// A Gauss-Hermite quadrature scheme.
 ///
@@ -97,7 +97,7 @@ impl GaussHermite {
     }
 }
 
-impl_data_api! {GaussHermite, GaussHermiteNodes, GaussHermiteWeights, GaussHermiteIter}
+impl_node_weight_rule_trait! {GaussHermite, GaussHermiteNodes, GaussHermiteWeights, GaussHermiteIter}
 
 #[cfg(test)]
 mod tests {

--- a/src/jacobi/iterators.rs
+++ b/src/jacobi/iterators.rs
@@ -2,4 +2,4 @@
 
 use super::GaussJacobi;
 
-crate::impl_iterators! {GaussJacobi, GaussJacobiNodes, GaussJacobiWeights, GaussJacobiIter, GaussJacobiIntoIter}
+crate::impl_node_weight_rule_iterators! {GaussJacobi, GaussJacobiNodes, GaussJacobiWeights, GaussJacobiIter, GaussJacobiIntoIter}

--- a/src/jacobi/iterators.rs
+++ b/src/jacobi/iterators.rs
@@ -1,5 +1,3 @@
 //! This module contains the iterators produced by some of the functions on [`GaussJacobi`].
 
-use super::GaussJacobi;
-
 crate::impl_node_weight_rule_iterators! {GaussJacobi, GaussJacobiNodes, GaussJacobiWeights, GaussJacobiIter, GaussJacobiIntoIter}

--- a/src/jacobi/iterators.rs
+++ b/src/jacobi/iterators.rs
@@ -1,3 +1,3 @@
 //! This module contains the iterators produced by some of the functions on [`GaussJacobi`](super::GaussJacobi).
 
-crate::impl_node_weight_rule_iterators! {GaussJacobi, GaussJacobiNodes, GaussJacobiWeights, GaussJacobiIter, GaussJacobiIntoIter}
+crate::impl_node_weight_rule_iterators! {GaussJacobiNodes, GaussJacobiWeights, GaussJacobiIter, GaussJacobiIntoIter}

--- a/src/jacobi/iterators.rs
+++ b/src/jacobi/iterators.rs
@@ -1,3 +1,3 @@
-//! This module contains the iterators produced by some of the functions on [`GaussJacobi`].
+//! This module contains the iterators produced by some of the functions on [`GaussJacobi`](super::GaussJacobi).
 
 crate::impl_node_weight_rule_iterators! {GaussJacobi, GaussJacobiNodes, GaussJacobiWeights, GaussJacobiIter, GaussJacobiIntoIter}

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -22,7 +22,7 @@ pub mod iterators;
 use iterators::{GaussJacobiIntoIter, GaussJacobiIter, GaussJacobiNodes, GaussJacobiWeights};
 
 use crate::gamma::gamma;
-use crate::{impl_node_weight_rule_trait, DMatrixf64, Node, Weight};
+use crate::{impl_node_weight_rule, DMatrixf64, Node, Weight};
 
 /// A Gauss-Jacobi quadrature scheme.
 ///
@@ -163,7 +163,7 @@ impl GaussJacobi {
     }
 }
 
-impl_node_weight_rule_trait! {GaussJacobi, GaussJacobiNodes, GaussJacobiWeights, GaussJacobiIter, GaussJacobiIntoIter}
+impl_node_weight_rule! {GaussJacobi, GaussJacobiNodes, GaussJacobiWeights, GaussJacobiIter, GaussJacobiIntoIter}
 
 #[cfg(test)]
 mod tests {

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -19,7 +19,7 @@
 //! ```
 
 pub mod iterators;
-use iterators::{GaussJacobiIter, GaussJacobiNodes, GaussJacobiWeights};
+use iterators::{GaussJacobiIntoIter, GaussJacobiIter, GaussJacobiNodes, GaussJacobiWeights};
 
 use crate::gamma::gamma;
 use crate::{impl_node_weight_rule_trait, DMatrixf64, Node, Weight};
@@ -163,7 +163,7 @@ impl GaussJacobi {
     }
 }
 
-impl_node_weight_rule_trait! {GaussJacobi, GaussJacobiNodes, GaussJacobiWeights, GaussJacobiIter}
+impl_node_weight_rule_trait! {GaussJacobi, GaussJacobiNodes, GaussJacobiWeights, GaussJacobiIter, GaussJacobiIntoIter}
 
 #[cfg(test)]
 mod tests {

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -22,7 +22,7 @@ pub mod iterators;
 use iterators::{GaussJacobiIter, GaussJacobiNodes, GaussJacobiWeights};
 
 use crate::gamma::gamma;
-use crate::{impl_data_api, DMatrixf64, Node, Weight};
+use crate::{impl_node_weight_rule_trait, DMatrixf64, Node, Weight};
 
 /// A Gauss-Jacobi quadrature scheme.
 ///
@@ -163,7 +163,7 @@ impl GaussJacobi {
     }
 }
 
-impl_data_api! {GaussJacobi, GaussJacobiNodes, GaussJacobiWeights, GaussJacobiIter}
+impl_node_weight_rule_trait! {GaussJacobi, GaussJacobiNodes, GaussJacobiWeights, GaussJacobiIter}
 
 #[cfg(test)]
 mod tests {

--- a/src/laguerre/iterators.rs
+++ b/src/laguerre/iterators.rs
@@ -1,3 +1,3 @@
-//! This module contains the iterators produced by some of the functions on [`GaussLaguerre`].
+//! This module contains the iterators produced by some of the functions on [`GaussLaguerre`](super::GaussLaguerre).
 
 crate::impl_node_weight_rule_iterators! {GaussLaguerre, GaussLaguerreNodes, GaussLaguerreWeights, GaussLaguerreIter, GaussLaguerreIntoIter}

--- a/src/laguerre/iterators.rs
+++ b/src/laguerre/iterators.rs
@@ -2,4 +2,4 @@
 
 use super::GaussLaguerre;
 
-crate::impl_iterators! {GaussLaguerre, GaussLaguerreNodes, GaussLaguerreWeights, GaussLaguerreIter, GaussLaguerreIntoIter}
+crate::impl_node_weight_rule_iterators! {GaussLaguerre, GaussLaguerreNodes, GaussLaguerreWeights, GaussLaguerreIter, GaussLaguerreIntoIter}

--- a/src/laguerre/iterators.rs
+++ b/src/laguerre/iterators.rs
@@ -1,3 +1,3 @@
 //! This module contains the iterators produced by some of the functions on [`GaussLaguerre`](super::GaussLaguerre).
 
-crate::impl_node_weight_rule_iterators! {GaussLaguerre, GaussLaguerreNodes, GaussLaguerreWeights, GaussLaguerreIter, GaussLaguerreIntoIter}
+crate::impl_node_weight_rule_iterators! {GaussLaguerreNodes, GaussLaguerreWeights, GaussLaguerreIter, GaussLaguerreIntoIter}

--- a/src/laguerre/iterators.rs
+++ b/src/laguerre/iterators.rs
@@ -1,5 +1,3 @@
 //! This module contains the iterators produced by some of the functions on [`GaussLaguerre`].
 
-use super::GaussLaguerre;
-
 crate::impl_node_weight_rule_iterators! {GaussLaguerre, GaussLaguerreNodes, GaussLaguerreWeights, GaussLaguerreIter, GaussLaguerreIntoIter}

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -18,7 +18,7 @@ pub mod iterators;
 use iterators::{GaussLaguerreIter, GaussLaguerreNodes, GaussLaguerreWeights};
 
 use crate::gamma::gamma;
-use crate::{impl_data_api, DMatrixf64, Node, Weight};
+use crate::{impl_node_weight_rule_trait, DMatrixf64, Node, Weight};
 
 /// A Gauss-Laguerre quadrature scheme.
 ///
@@ -129,7 +129,7 @@ impl GaussLaguerre {
     }
 }
 
-impl_data_api! {GaussLaguerre, GaussLaguerreNodes, GaussLaguerreWeights, GaussLaguerreIter}
+impl_node_weight_rule_trait! {GaussLaguerre, GaussLaguerreNodes, GaussLaguerreWeights, GaussLaguerreIter}
 
 #[cfg(test)]
 mod tests {

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -15,7 +15,9 @@
 //! ```
 
 pub mod iterators;
-use iterators::{GaussLaguerreIter, GaussLaguerreNodes, GaussLaguerreWeights};
+use iterators::{
+    GaussLaguerreIntoIter, GaussLaguerreIter, GaussLaguerreNodes, GaussLaguerreWeights,
+};
 
 use crate::gamma::gamma;
 use crate::{impl_node_weight_rule_trait, DMatrixf64, Node, Weight};
@@ -129,7 +131,7 @@ impl GaussLaguerre {
     }
 }
 
-impl_node_weight_rule_trait! {GaussLaguerre, GaussLaguerreNodes, GaussLaguerreWeights, GaussLaguerreIter}
+impl_node_weight_rule_trait! {GaussLaguerre, GaussLaguerreNodes, GaussLaguerreWeights, GaussLaguerreIter, GaussLaguerreIntoIter}
 
 #[cfg(test)]
 mod tests {

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -20,7 +20,7 @@ use iterators::{
 };
 
 use crate::gamma::gamma;
-use crate::{impl_node_weight_rule_trait, DMatrixf64, Node, Weight};
+use crate::{impl_node_weight_rule, DMatrixf64, Node, Weight};
 
 /// A Gauss-Laguerre quadrature scheme.
 ///
@@ -131,7 +131,7 @@ impl GaussLaguerre {
     }
 }
 
-impl_node_weight_rule_trait! {GaussLaguerre, GaussLaguerreNodes, GaussLaguerreWeights, GaussLaguerreIter, GaussLaguerreIntoIter}
+impl_node_weight_rule! {GaussLaguerre, GaussLaguerreNodes, GaussLaguerreWeights, GaussLaguerreIter, GaussLaguerreIntoIter}
 
 #[cfg(test)]
 mod tests {

--- a/src/legendre/iterators.rs
+++ b/src/legendre/iterators.rs
@@ -1,3 +1,3 @@
 //! This module contains the iterators produced by some of the functions on [`GaussLegendre`](super::GaussLegendre).
 
-crate::impl_node_weight_rule_iterators! {GaussLegendre, GaussLegendreNodes, GaussLegendreWeights, GaussLegendreIter, GaussLegendreIntoIter}
+crate::impl_node_weight_rule_iterators! {GaussLegendreNodes, GaussLegendreWeights, GaussLegendreIter, GaussLegendreIntoIter}

--- a/src/legendre/iterators.rs
+++ b/src/legendre/iterators.rs
@@ -1,3 +1,3 @@
-//! This module contains the iterators produced by some of the functions on [`GaussLegendre`].
+//! This module contains the iterators produced by some of the functions on [`GaussLegendre`](super::GaussLegendre).
 
 crate::impl_node_weight_rule_iterators! {GaussLegendre, GaussLegendreNodes, GaussLegendreWeights, GaussLegendreIter, GaussLegendreIntoIter}

--- a/src/legendre/iterators.rs
+++ b/src/legendre/iterators.rs
@@ -1,5 +1,3 @@
 //! This module contains the iterators produced by some of the functions on [`GaussLegendre`].
 
-use super::GaussLegendre;
-
 crate::impl_node_weight_rule_iterators! {GaussLegendre, GaussLegendreNodes, GaussLegendreWeights, GaussLegendreIter, GaussLegendreIntoIter}

--- a/src/legendre/iterators.rs
+++ b/src/legendre/iterators.rs
@@ -2,4 +2,4 @@
 
 use super::GaussLegendre;
 
-crate::impl_iterators! {GaussLegendre, GaussLegendreNodes, GaussLegendreWeights, GaussLegendreIter, GaussLegendreIntoIter}
+crate::impl_node_weight_rule_iterators! {GaussLegendre, GaussLegendreNodes, GaussLegendreWeights, GaussLegendreIter, GaussLegendreIntoIter}

--- a/src/legendre/mod.rs
+++ b/src/legendre/mod.rs
@@ -22,7 +22,9 @@
 //! ```
 
 pub mod iterators;
-use iterators::{GaussLegendreIter, GaussLegendreNodes, GaussLegendreWeights};
+use iterators::{
+    GaussLegendreIntoIter, GaussLegendreIter, GaussLegendreNodes, GaussLegendreWeights,
+};
 
 use bogaert::NodeWeightPair;
 
@@ -101,7 +103,7 @@ impl GaussLegendre {
     }
 }
 
-impl_node_weight_rule_trait! {GaussLegendre, GaussLegendreNodes, GaussLegendreWeights, GaussLegendreIter}
+impl_node_weight_rule_trait! {GaussLegendre, GaussLegendreNodes, GaussLegendreWeights, GaussLegendreIter, GaussLegendreIntoIter}
 
 /// This algorithm is based on an expansion of Legendre polynomials in terms of Bessel functions
 /// where for large degrees only the first terms in the expansion matter. This means that

--- a/src/legendre/mod.rs
+++ b/src/legendre/mod.rs
@@ -28,7 +28,7 @@ use iterators::{
 
 use bogaert::NodeWeightPair;
 
-use crate::{impl_node_weight_rule_trait, Node, Weight};
+use crate::{impl_node_weight_rule, Node, Weight};
 
 /// A Gauss-Legendre quadrature scheme.
 ///
@@ -103,7 +103,7 @@ impl GaussLegendre {
     }
 }
 
-impl_node_weight_rule_trait! {GaussLegendre, GaussLegendreNodes, GaussLegendreWeights, GaussLegendreIter, GaussLegendreIntoIter}
+impl_node_weight_rule! {GaussLegendre, GaussLegendreNodes, GaussLegendreWeights, GaussLegendreIter, GaussLegendreIntoIter}
 
 /// This algorithm is based on an expansion of Legendre polynomials in terms of Bessel functions
 /// where for large degrees only the first terms in the expansion matter. This means that

--- a/src/legendre/mod.rs
+++ b/src/legendre/mod.rs
@@ -26,7 +26,7 @@ use iterators::{GaussLegendreIter, GaussLegendreNodes, GaussLegendreWeights};
 
 use bogaert::NodeWeightPair;
 
-use crate::{impl_data_api, Node, Weight};
+use crate::{impl_node_weight_rule_trait, Node, Weight};
 
 /// A Gauss-Legendre quadrature scheme.
 ///
@@ -101,7 +101,7 @@ impl GaussLegendre {
     }
 }
 
-impl_data_api! {GaussLegendre, GaussLegendreNodes, GaussLegendreWeights, GaussLegendreIter}
+impl_node_weight_rule_trait! {GaussLegendre, GaussLegendreNodes, GaussLegendreWeights, GaussLegendreIter}
 
 /// This algorithm is based on an expansion of Legendre polynomials in terms of Bessel functions
 /// where for large degrees only the first terms in the expansion matter. This means that

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ pub mod midpoint;
 pub mod simpson;
 
 #[doc(inline)]
-pub use data_api::{Node, NodeRule, NodeWeightRule, Weight};
+pub use data_api::{Node, Weight};
 #[doc(inline)]
 pub use hermite::GaussHermite;
 #[doc(inline)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,8 @@ pub mod midpoint;
 pub mod simpson;
 
 #[doc(inline)]
+pub use data_api::{Node, NodeRule, NodeWeightRule, Weight};
+#[doc(inline)]
 pub use hermite::GaussHermite;
 #[doc(inline)]
 pub use jacobi::GaussJacobi;
@@ -156,47 +158,3 @@ pub use legendre::GaussLegendre;
 pub use midpoint::Midpoint;
 #[doc(inline)]
 pub use simpson::Simpson;
-
-/// A node in a quadrature rule.
-pub type Node = f64;
-/// A weight in a quadrature rule.
-pub type Weight = f64;
-
-/// This trait defines the API for reading the underlying data in quadrature rules that have
-/// both nodes and weights.
-pub trait NodeWeightRule
-where
-    Self: IntoIterator,
-{
-    /// The type of the nodes.
-    type Node;
-    /// The type of the weights.
-    type Weight;
-    /// An iterator over node-weight-pairs of the quadrature rule.
-    type Iter<'a>: Iterator<Item = &'a (Self::Node, Self::Weight)>
-    where
-        Self: 'a;
-    /// An iterator over the nodes of the quadrature rule.
-    type Nodes<'a>: Iterator<Item = &'a Self::Node>
-    where
-        Self: 'a;
-    /// An iterator over the weights of the quadrature rule.
-    type Weights<'a>: Iterator<Item = &'a Self::Weight>
-    where
-        Self: 'a;
-    /// Returns an iterator over the node-weight-pairs of the quadrature rule.
-    fn iter(&self) -> Self::Iter<'_>;
-    /// Returns an iterator over the nodes of the quadrature rule.
-    fn nodes(&self) -> Self::Nodes<'_>;
-    /// Returns an iterator over the weights of the quadrature rule.
-    fn weights(&self) -> Self::Weights<'_>;
-    /// Returns a slice of the node-weight-pairs of the quadrature rule.
-    fn as_node_weight_pairs<'a>(&'a self) -> &'a [(Self::Node, Self::Weight)];
-    /// Converts the quadrature rule into a vector of node-weight-pairs.
-    ///
-    /// This function just returns the underlying data and does no
-    /// computation or cloning.
-    fn into_node_weight_pairs(self) -> Vec<(Self::Node, Self::Weight)>;
-    /// Returns the degree of the quadrature rule.
-    fn degree(&self) -> usize;
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,3 +161,42 @@ pub use simpson::Simpson;
 pub type Node = f64;
 /// A weight in a quadrature rule.
 pub type Weight = f64;
+
+/// This trait defines the API for reading the underlying data in quadrature rules that have
+/// both nodes and weights.
+pub trait NodeWeightRule
+where
+    Self: IntoIterator,
+{
+    /// The type of the nodes.
+    type Node;
+    /// The type of the weights.
+    type Weight;
+    /// An iterator over node-weight-pairs of the quadrature rule.
+    type Iter<'a>: Iterator<Item = &'a (Self::Node, Self::Weight)>
+    where
+        Self: 'a;
+    /// An iterator over the nodes of the quadrature rule.
+    type Nodes<'a>: Iterator<Item = &'a Self::Node>
+    where
+        Self: 'a;
+    /// An iterator over the weights of the quadrature rule.
+    type Weights<'a>: Iterator<Item = &'a Self::Weight>
+    where
+        Self: 'a;
+    /// Returns an iterator over the node-weight-pairs of the quadrature rule.
+    fn iter(&self) -> Self::Iter<'_>;
+    /// Returns an iterator over the nodes of the quadrature rule.
+    fn nodes(&self) -> Self::Nodes<'_>;
+    /// Returns an iterator over the weights of the quadrature rule.
+    fn weights(&self) -> Self::Weights<'_>;
+    /// Returns a slice of the node-weight-pairs of the quadrature rule.
+    fn as_node_weight_pairs<'a>(&'a self) -> &'a [(Self::Node, Self::Weight)];
+    /// Converts the quadrature rule into a vector of node-weight-pairs.
+    ///
+    /// This function just returns the underlying data and does no
+    /// computation or cloning.
+    fn into_node_weight_pairs(self) -> Vec<(Self::Node, Self::Weight)>;
+    /// Returns the degree of the quadrature rule.
+    fn degree(&self) -> usize;
+}

--- a/src/midpoint/iterators.rs
+++ b/src/midpoint/iterators.rs
@@ -3,4 +3,4 @@
 
 use crate::impl_node_rule_iterators;
 
-impl_node_rule_iterators! {Midpoint, MidpointIter, MidpointIntoIter}
+impl_node_rule_iterators! {MidpointIter, MidpointIntoIter}

--- a/src/midpoint/iterators.rs
+++ b/src/midpoint/iterators.rs
@@ -1,5 +1,5 @@
 //! This crate contains the implementation of the iterators that
-//! can be returned by method calls on a [`Midpoint`] instance.
+//! can be returned by method calls on a [`Midpoint`](super::Midpoint) instance.
 
 use crate::impl_node_rule_iterators;
 

--- a/src/midpoint/iterators.rs
+++ b/src/midpoint/iterators.rs
@@ -1,6 +1,7 @@
 //! This crate contains the implementation of the iterators that
-//! can be returned by method calls on a [`Midpoint`](super::Midpoint) instance.
+//! can be returned by method calls on a [`Midpoint`] instance.
 
+use super::Midpoint;
 use crate::impl_node_rule_iterators;
 
-impl_node_rule_iterators! {Midpoint, MidpointIter}
+impl_node_rule_iterators! {Midpoint, MidpointIter, MidpointIntoIter}

--- a/src/midpoint/iterators.rs
+++ b/src/midpoint/iterators.rs
@@ -1,7 +1,6 @@
 //! This crate contains the implementation of the iterators that
 //! can be returned by method calls on a [`Midpoint`] instance.
 
-use super::Midpoint;
 use crate::impl_node_rule_iterators;
 
 impl_node_rule_iterators! {Midpoint, MidpointIter, MidpointIntoIter}

--- a/src/midpoint/iterators.rs
+++ b/src/midpoint/iterators.rs
@@ -6,7 +6,6 @@ use core::iter::FusedIterator;
 use core::slice::Iter;
 
 /// An iterator of the nodes of a [`Midpoint`](super::Midpoint) instance.
-/// Created by the [`Midpoint::iter`](super::Midpoint::iter) function, see it for more information.
 #[derive(Debug, Clone)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 pub struct MidpointIter<'a>(Iter<'a, f64>);

--- a/src/midpoint/iterators.rs
+++ b/src/midpoint/iterators.rs
@@ -1,54 +1,6 @@
 //! This crate contains the implementation of the iterators that
 //! can be returned by method calls on a [`Midpoint`](super::Midpoint) instance.
 
-use crate::Node;
-use core::iter::FusedIterator;
-use core::slice::Iter;
+use crate::impl_node_rule_iterators;
 
-/// An iterator of the nodes of a [`Midpoint`](super::Midpoint) instance.
-#[derive(Debug, Clone)]
-#[must_use = "iterators are lazy and do nothing unless consumed"]
-pub struct MidpointIter<'a>(Iter<'a, f64>);
-
-impl<'a> MidpointIter<'a> {
-    #[inline]
-    pub(super) fn new(iter: Iter<'a, f64>) -> Self {
-        Self(iter)
-    }
-
-    /// Views the underlying data as a subslice of the original data.
-    ///
-    /// See [`core::slice::Iter::as_slice`] for more information.
-    #[inline]
-    pub fn as_slice(&self) -> &'a [Node] {
-        self.0.as_slice()
-    }
-}
-
-impl<'a> AsRef<[Node]> for MidpointIter<'a> {
-    #[inline]
-    fn as_ref(&self) -> &[Node] {
-        self.0.as_ref()
-    }
-}
-
-impl<'a> Iterator for MidpointIter<'a> {
-    type Item = &'a Node;
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.next()
-    }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.0.size_hint()
-    }
-}
-
-impl<'a> DoubleEndedIterator for MidpointIter<'a> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        self.0.next_back()
-    }
-}
-
-impl<'a> ExactSizeIterator for MidpointIter<'a> {}
-impl<'a> FusedIterator for MidpointIter<'a> {}
+impl_node_rule_iterators! {Midpoint, MidpointIter}

--- a/src/midpoint/mod.rs
+++ b/src/midpoint/mod.rs
@@ -42,7 +42,7 @@
 
 pub mod iterators;
 
-use crate::{Node, NodeRule};
+use crate::{impl_node_rule_trait, Node};
 use iterators::MidpointIter;
 
 /// A midpoint rule quadrature scheme.
@@ -95,36 +95,7 @@ impl Midpoint {
     }
 }
 
-impl NodeRule for Midpoint {
-    type Node = Node;
-    type Iter<'a> = MidpointIter<'a>;
-    #[inline]
-    fn iter(&self) -> MidpointIter<'_> {
-        MidpointIter::new(self.nodes.iter())
-    }
-
-    #[inline]
-    fn as_nodes(&self) -> &[Node] {
-        &self.nodes
-    }
-    #[inline]
-    fn into_nodes(self) -> Vec<Node> {
-        self.nodes
-    }
-
-    #[inline]
-    fn degree(&self) -> usize {
-        self.nodes.len()
-    }
-}
-
-impl IntoIterator for Midpoint {
-    type IntoIter = std::vec::IntoIter<Node>;
-    type Item = Node;
-    fn into_iter(self) -> Self::IntoIter {
-        self.nodes.into_iter()
-    }
-}
+impl_node_rule_trait! {Midpoint, MidpointIter}
 
 #[cfg(test)]
 mod tests {

--- a/src/midpoint/mod.rs
+++ b/src/midpoint/mod.rs
@@ -43,7 +43,7 @@
 pub mod iterators;
 
 use crate::{impl_node_rule_trait, Node};
-use iterators::MidpointIter;
+use iterators::{MidpointIntoIter, MidpointIter};
 
 /// A midpoint rule quadrature scheme.
 /// ```
@@ -95,7 +95,7 @@ impl Midpoint {
     }
 }
 
-impl_node_rule_trait! {Midpoint, MidpointIter}
+impl_node_rule_trait! {Midpoint, MidpointIter, MidpointIntoIter}
 
 #[cfg(test)]
 mod tests {

--- a/src/midpoint/mod.rs
+++ b/src/midpoint/mod.rs
@@ -42,7 +42,7 @@
 
 pub mod iterators;
 
-use crate::Node;
+use crate::{Node, NodeRule};
 use iterators::MidpointIter;
 
 /// A midpoint rule quadrature scheme.
@@ -78,26 +78,6 @@ impl Midpoint {
         }
     }
 
-    /// Returns an iterator over the nodes of the midpoint rule.
-    #[inline]
-    pub fn iter(&self) -> MidpointIter<'_> {
-        MidpointIter::new(self.nodes.iter())
-    }
-
-    /// Returns the nodes of the rule as a slice.
-    #[inline]
-    pub fn as_nodes(&self) -> &[Node] {
-        &self.nodes
-    }
-
-    /// Converts `self` into a vector of nodes.
-    ///
-    /// Simply returns the underlying vector with no computation or allocation.
-    #[inline]
-    pub fn into_nodes(self) -> Vec<Node> {
-        self.nodes
-    }
-
     /// Integrate over the domain [a, b].
     pub fn integrate<F>(&self, a: f64, b: f64, integrand: F) -> f64
     where
@@ -112,6 +92,29 @@ impl Midpoint {
             .sum();
 
         sum * rect_width
+    }
+}
+
+impl NodeRule for Midpoint {
+    type Node = Node;
+    type Iter<'a> = MidpointIter<'a>;
+    #[inline]
+    fn iter(&self) -> MidpointIter<'_> {
+        MidpointIter::new(self.nodes.iter())
+    }
+
+    #[inline]
+    fn as_nodes(&self) -> &[Node] {
+        &self.nodes
+    }
+    #[inline]
+    fn into_nodes(self) -> Vec<Node> {
+        self.nodes
+    }
+
+    #[inline]
+    fn degree(&self) -> usize {
+        self.nodes.len()
     }
 }
 

--- a/src/simpson/iterators.rs
+++ b/src/simpson/iterators.rs
@@ -3,4 +3,4 @@
 
 use crate::impl_node_rule_iterators;
 
-impl_node_rule_iterators! { Simpson, SimpsonIter, SimpsonIntoIter}
+impl_node_rule_iterators! { SimpsonIter, SimpsonIntoIter}

--- a/src/simpson/iterators.rs
+++ b/src/simpson/iterators.rs
@@ -3,4 +3,4 @@
 
 use crate::impl_node_rule_iterators;
 
-impl_node_rule_iterators! { SimpsonIter, SimpsonIntoIter}
+impl_node_rule_iterators! {SimpsonIter, SimpsonIntoIter}

--- a/src/simpson/iterators.rs
+++ b/src/simpson/iterators.rs
@@ -1,5 +1,5 @@
 //! This crate contains the implementation of the iterators that
-//! can be returned by method calls on a [`Simpson`] instance.
+//! can be returned by method calls on a [`Simpson`](super::Simpson) instance.
 
 use crate::impl_node_rule_iterators;
 

--- a/src/simpson/iterators.rs
+++ b/src/simpson/iterators.rs
@@ -5,7 +5,6 @@ use crate::Node;
 use core::{iter::FusedIterator, slice::Iter};
 
 /// An iterator of the nodes of a [`Simpson`](super::Simpson) instance.
-/// Created by the [`Simpson::iter`](super::Simpson::iter) function, see it for more information.
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
 pub struct SimpsonIter<'a>(Iter<'a, Node>);

--- a/src/simpson/iterators.rs
+++ b/src/simpson/iterators.rs
@@ -1,7 +1,6 @@
 //! This crate contains the implementation of the iterators that
 //! can be returned by method calls on a [`Simpson`] instance.
 
-use super::Simpson;
 use crate::impl_node_rule_iterators;
 
 impl_node_rule_iterators! { Simpson, SimpsonIter, SimpsonIntoIter}

--- a/src/simpson/iterators.rs
+++ b/src/simpson/iterators.rs
@@ -1,53 +1,54 @@
 //! This crate contains the implementation of the iterators that
 //! can be returned by method calls on a [`Simpson`](super::Simpson) instance.
 
-use crate::Node;
-use core::{iter::FusedIterator, slice::Iter};
+use crate::impl_node_rule_iterators;
 
-/// An iterator of the nodes of a [`Simpson`](super::Simpson) instance.
-#[must_use = "iterators are lazy and do nothing unless consumed"]
-#[derive(Debug, Clone)]
-pub struct SimpsonIter<'a>(Iter<'a, Node>);
+impl_node_rule_iterators! { Simpson, SimpsonIter }
 
-impl<'a> SimpsonIter<'a> {
-    #[inline]
-    pub(super) fn new(iter: Iter<'a, Node>) -> Self {
-        Self(iter)
-    }
+// /// An iterator of the nodes of a [`Simpson`](super::Simpson) instance.
+// #[must_use = "iterators are lazy and do nothing unless consumed"]
+// #[derive(Debug, Clone)]
+// pub struct SimpsonIter<'a>(Iter<'a, Node>);
 
-    /// Views the underlying data as a subslice of the original data.
-    ///
-    /// See [`core::slice::Iter::as_slice`] for more information.
-    #[inline]
-    pub fn as_slice(&self) -> &'a [Node] {
-        self.0.as_slice()
-    }
-}
+// impl<'a> SimpsonIter<'a> {
+//     #[inline]
+//     pub(super) fn new(iter: Iter<'a, Node>) -> Self {
+//         Self(iter)
+//     }
 
-impl<'a> AsRef<[Node]> for SimpsonIter<'a> {
-    #[inline]
-    fn as_ref(&self) -> &[Node] {
-        self.0.as_ref()
-    }
-}
+//     /// Views the underlying data as a subslice of the original data.
+//     ///
+//     /// See [`core::slice::Iter::as_slice`] for more information.
+//     #[inline]
+//     pub fn as_slice(&self) -> &'a [Node] {
+//         self.0.as_slice()
+//     }
+// }
 
-impl<'a> Iterator for SimpsonIter<'a> {
-    type Item = &'a Node;
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.next()
-    }
+// impl<'a> AsRef<[Node]> for SimpsonIter<'a> {
+//     #[inline]
+//     fn as_ref(&self) -> &[Node] {
+//         self.0.as_ref()
+//     }
+// }
 
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.0.size_hint()
-    }
-}
+// impl<'a> Iterator for SimpsonIter<'a> {
+//     type Item = &'a Node;
+//     fn next(&mut self) -> Option<Self::Item> {
+//         self.0.next()
+//     }
 
-impl<'a> DoubleEndedIterator for SimpsonIter<'a> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        self.0.next_back()
-    }
-}
+//     #[inline]
+//     fn size_hint(&self) -> (usize, Option<usize>) {
+//         self.0.size_hint()
+//     }
+// }
 
-impl<'a> ExactSizeIterator for SimpsonIter<'a> {}
-impl<'a> FusedIterator for SimpsonIter<'a> {}
+// impl<'a> DoubleEndedIterator for SimpsonIter<'a> {
+//     fn next_back(&mut self) -> Option<Self::Item> {
+//         self.0.next_back()
+//     }
+// }
+
+// impl<'a> ExactSizeIterator for SimpsonIter<'a> {}
+// impl<'a> FusedIterator for SimpsonIter<'a> {}

--- a/src/simpson/iterators.rs
+++ b/src/simpson/iterators.rs
@@ -1,54 +1,7 @@
 //! This crate contains the implementation of the iterators that
-//! can be returned by method calls on a [`Simpson`](super::Simpson) instance.
+//! can be returned by method calls on a [`Simpson`] instance.
 
+use super::Simpson;
 use crate::impl_node_rule_iterators;
 
-impl_node_rule_iterators! { Simpson, SimpsonIter }
-
-// /// An iterator of the nodes of a [`Simpson`](super::Simpson) instance.
-// #[must_use = "iterators are lazy and do nothing unless consumed"]
-// #[derive(Debug, Clone)]
-// pub struct SimpsonIter<'a>(Iter<'a, Node>);
-
-// impl<'a> SimpsonIter<'a> {
-//     #[inline]
-//     pub(super) fn new(iter: Iter<'a, Node>) -> Self {
-//         Self(iter)
-//     }
-
-//     /// Views the underlying data as a subslice of the original data.
-//     ///
-//     /// See [`core::slice::Iter::as_slice`] for more information.
-//     #[inline]
-//     pub fn as_slice(&self) -> &'a [Node] {
-//         self.0.as_slice()
-//     }
-// }
-
-// impl<'a> AsRef<[Node]> for SimpsonIter<'a> {
-//     #[inline]
-//     fn as_ref(&self) -> &[Node] {
-//         self.0.as_ref()
-//     }
-// }
-
-// impl<'a> Iterator for SimpsonIter<'a> {
-//     type Item = &'a Node;
-//     fn next(&mut self) -> Option<Self::Item> {
-//         self.0.next()
-//     }
-
-//     #[inline]
-//     fn size_hint(&self) -> (usize, Option<usize>) {
-//         self.0.size_hint()
-//     }
-// }
-
-// impl<'a> DoubleEndedIterator for SimpsonIter<'a> {
-//     fn next_back(&mut self) -> Option<Self::Item> {
-//         self.0.next_back()
-//     }
-// }
-
-// impl<'a> ExactSizeIterator for SimpsonIter<'a> {}
-// impl<'a> FusedIterator for SimpsonIter<'a> {}
+impl_node_rule_iterators! { Simpson, SimpsonIter, SimpsonIntoIter}

--- a/src/simpson/mod.rs
+++ b/src/simpson/mod.rs
@@ -35,7 +35,7 @@
 
 pub mod iterators;
 
-use crate::{Node, NodeRule};
+use crate::{impl_node_rule_trait, Node};
 use iterators::SimpsonIter;
 
 /// A Simpson rule quadrature scheme.
@@ -99,38 +99,7 @@ impl Simpson {
     }
 }
 
-impl NodeRule for Simpson {
-    type Node = Node;
-    type Iter<'a> = SimpsonIter<'a>;
-
-    #[inline]
-    fn iter(&self) -> SimpsonIter<'_> {
-        SimpsonIter::new(self.nodes.iter())
-    }
-
-    #[inline]
-    fn as_nodes(&self) -> &[Node] {
-        &self.nodes
-    }
-
-    #[inline]
-    fn into_nodes(self) -> Vec<Node> {
-        self.nodes
-    }
-
-    #[inline]
-    fn degree(&self) -> usize {
-        self.nodes.len()
-    }
-}
-
-impl IntoIterator for Simpson {
-    type IntoIter = std::vec::IntoIter<Node>;
-    type Item = Node;
-    fn into_iter(self) -> Self::IntoIter {
-        self.nodes.into_iter()
-    }
-}
+impl_node_rule_trait! {Simpson, SimpsonIter}
 
 #[cfg(test)]
 mod tests {

--- a/src/simpson/mod.rs
+++ b/src/simpson/mod.rs
@@ -35,7 +35,7 @@
 
 pub mod iterators;
 
-use crate::Node;
+use crate::{Node, NodeRule};
 use iterators::SimpsonIter;
 
 /// A Simpson rule quadrature scheme.
@@ -62,26 +62,6 @@ impl Simpson {
         Self {
             nodes: (0..degree).map(|d| d as f64).collect(),
         }
-    }
-
-    /// Returns an iterator over the nodes of the rule.
-    #[inline]
-    pub fn iter(&self) -> SimpsonIter<'_> {
-        SimpsonIter::new(self.nodes.iter())
-    }
-
-    /// Returns a slice of all the nodes of the rule.
-    #[inline]
-    pub fn as_nodes(&self) -> &[Node] {
-        &self.nodes
-    }
-
-    /// Converts `self` into a vector of nodes.
-    ///
-    /// Simply returns the underlying vector without any computation or allocation.
-    #[inline]
-    pub fn into_nodes(self) -> Vec<Node> {
-        self.nodes
     }
 
     /// Integrate over the domain [a, b].
@@ -116,6 +96,31 @@ impl Simpson {
                 + 4.0 * integrand(a + (2.0 * n - 1.0) * h / 2.0)
                 + integrand(a)
                 + integrand(b))
+    }
+}
+
+impl NodeRule for Simpson {
+    type Node = Node;
+    type Iter<'a> = SimpsonIter<'a>;
+
+    #[inline]
+    fn iter(&self) -> SimpsonIter<'_> {
+        SimpsonIter::new(self.nodes.iter())
+    }
+
+    #[inline]
+    fn as_nodes(&self) -> &[Node] {
+        &self.nodes
+    }
+
+    #[inline]
+    fn into_nodes(self) -> Vec<Node> {
+        self.nodes
+    }
+
+    #[inline]
+    fn degree(&self) -> usize {
+        self.nodes.len()
     }
 }
 

--- a/src/simpson/mod.rs
+++ b/src/simpson/mod.rs
@@ -36,7 +36,7 @@
 pub mod iterators;
 
 use crate::{impl_node_rule_trait, Node};
-use iterators::SimpsonIter;
+use iterators::{SimpsonIntoIter, SimpsonIter};
 
 /// A Simpson rule quadrature scheme.
 /// ```
@@ -99,7 +99,7 @@ impl Simpson {
     }
 }
 
-impl_node_rule_trait! {Simpson, SimpsonIter}
+impl_node_rule_trait! {Simpson, SimpsonIter, SimpsonIntoIter}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This PR defines two macros that implement the data access API also for Midpoint and Simpson, and shortens the code by more efficiently repeating code blocks that are the same by the use of another macro.

It basically just implement the non-trait improvements from #57, as a trait is not the right tool for something like this.