### PR TITLE
Move the definition of the iterators into the same module as where the quadrature rule structs are defined?

### DIFF
--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -169,7 +169,7 @@ macro_rules! impl_node_weight_rule_iterators {
 
         impl<'a> $quadrature_rule_nodes<'a> {
             #[inline]
-            fn new(
+            const fn new(
                 iter_map: ::std::iter::Map<
                     ::core::slice::Iter<'a, ($crate::Node, $crate::Weight)>,
                     fn(&'a ($crate::Node, $crate::Weight)) -> &'a $crate::Node,
@@ -198,7 +198,7 @@ macro_rules! impl_node_weight_rule_iterators {
 
         impl<'a> $quadrature_rule_weights<'a> {
             #[inline]
-            fn new(
+            const fn new(
                 iter_map: ::std::iter::Map<
                     ::core::slice::Iter<'a, ($crate::Node, $crate::Weight)>,
                     fn(&'a ($crate::Node, $crate::Weight)) -> &'a $crate::Weight,
@@ -225,7 +225,7 @@ macro_rules! impl_node_weight_rule_iterators {
 
         impl<'a> $quadrature_rule_iter<'a> {
             #[inline]
-            fn new(
+            const fn new(
                 node_weight_pairs: ::core::slice::Iter<'a, ($crate::Node, $crate::Weight)>,
             ) -> Self {
                 Self(node_weight_pairs)
@@ -264,7 +264,7 @@ macro_rules! impl_node_weight_rule_iterators {
 
         impl $quadrature_rule_into_iter {
             #[inline]
-            fn new(
+            const fn new(
                 node_weight_pairs: ::std::vec::IntoIter<($crate::Node, $crate::Weight)>,
             ) -> Self {
                 Self(node_weight_pairs)
@@ -377,7 +377,7 @@ macro_rules! impl_node_rule_iterators {
 
         impl<'a> $quadrature_rule_iter<'a> {
             #[inline]
-            fn new(iter: ::core::slice::Iter<'a, $crate::Node>) -> Self {
+            const fn new(iter: ::core::slice::Iter<'a, $crate::Node>) -> Self {
                 Self(iter)
             }
 
@@ -412,7 +412,7 @@ macro_rules! impl_node_rule_iterators {
 
         impl $quadrature_rule_into_iter {
             #[inline]
-            fn new(iter: ::std::vec::IntoIter<$crate::Node>) -> Self {
+            const fn new(iter: ::std::vec::IntoIter<$crate::Node>) -> Self {
                 Self(iter)
             }
 

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -143,8 +143,7 @@ macro_rules! impl_slice_iterator_newtype_traits {
 /// This macro defines the iterators used by the functions defined in the [`impl_node_weight_rule!`] macro.
 /// It takes in the names of the same structs as that macro,
 /// plus the name it should give the iterator that is returned by the [`IntoIterator`] implementation.
-/// These iterators can only be created in the module where the macro is called
-/// or the module above it (due to the `pub(super)` marker on the constructors).
+/// These iterators can only be created in the module where the macro is called.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! impl_node_weight_rule_iterators {
@@ -170,7 +169,7 @@ macro_rules! impl_node_weight_rule_iterators {
 
         impl<'a> $quadrature_rule_nodes<'a> {
             #[inline]
-            pub(super) fn new(
+            fn new(
                 iter_map: ::std::iter::Map<
                     ::core::slice::Iter<'a, ($crate::Node, $crate::Weight)>,
                     fn(&'a ($crate::Node, $crate::Weight)) -> &'a $crate::Node,
@@ -199,7 +198,7 @@ macro_rules! impl_node_weight_rule_iterators {
 
         impl<'a> $quadrature_rule_weights<'a> {
             #[inline]
-            pub(super) fn new(
+            fn new(
                 iter_map: ::std::iter::Map<
                     ::core::slice::Iter<'a, ($crate::Node, $crate::Weight)>,
                     fn(&'a ($crate::Node, $crate::Weight)) -> &'a $crate::Weight,
@@ -226,7 +225,7 @@ macro_rules! impl_node_weight_rule_iterators {
 
         impl<'a> $quadrature_rule_iter<'a> {
             #[inline]
-            pub(super) fn new(
+            fn new(
                 node_weight_pairs: ::core::slice::Iter<'a, ($crate::Node, $crate::Weight)>,
             ) -> Self {
                 Self(node_weight_pairs)
@@ -265,7 +264,7 @@ macro_rules! impl_node_weight_rule_iterators {
 
         impl $quadrature_rule_into_iter {
             #[inline]
-            pub(super) fn new(
+            fn new(
                 node_weight_pairs: ::std::vec::IntoIter<($crate::Node, $crate::Weight)>,
             ) -> Self {
                 Self(node_weight_pairs)
@@ -364,8 +363,7 @@ macro_rules! impl_node_rule_trait {
 /// This macro defines the iterators used by the functions defined by the [`impl_node_rule_trait`] macro.
 /// It takes in the names of the same structs as that macro,
 /// plus the name it should give the iterator that is returned by the [`IntoIterator`] implementation.
-/// These iterators can only be created in the module where the macro is called
-/// or the module above it (due to the `pub(super)` marker on the constructors).
+/// These iterators can only be created in the module where the macro is called.
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_node_rule_iterators {
@@ -379,7 +377,7 @@ macro_rules! impl_node_rule_iterators {
 
         impl<'a> $quadrature_rule_iter<'a> {
             #[inline]
-            pub(super) fn new(iter: ::core::slice::Iter<'a, $crate::Node>) -> Self {
+            fn new(iter: ::core::slice::Iter<'a, $crate::Node>) -> Self {
                 Self(iter)
             }
 
@@ -414,7 +412,7 @@ macro_rules! impl_node_rule_iterators {
 
         impl $quadrature_rule_into_iter {
             #[inline]
-            pub(super) fn new(iter: ::std::vec::IntoIter<$crate::Node>) -> Self {
+            fn new(iter: ::std::vec::IntoIter<$crate::Node>) -> Self {
                 Self(iter)
             }
 

--- a/src/hermite/iterators.rs
+++ b/src/hermite/iterators.rs
@@ -1,3 +1,0 @@
-//! This module contains the iterators produced by some of the functions on [`GaussHermite`](super::GaussHermite).
-
-crate::impl_node_weight_rule_iterators! {GaussHermiteNodes, GaussHermiteWeights, GaussHermiteIter, GaussHermiteIntoIter}

--- a/src/hermite/mod.rs
+++ b/src/hermite/mod.rs
@@ -15,10 +15,7 @@
 //! assert_abs_diff_eq!(integral, core::f64::consts::PI.sqrt() / 2.0, epsilon = 1e-14);
 //! ```
 
-pub mod iterators;
-use iterators::{GaussHermiteIntoIter, GaussHermiteIter, GaussHermiteNodes, GaussHermiteWeights};
-
-use crate::{impl_node_weight_rule, DMatrixf64, Node, Weight, PI};
+use crate::{impl_node_weight_rule, impl_node_weight_rule_iterators, DMatrixf64, Node, Weight, PI};
 
 /// A Gauss-Hermite quadrature scheme.
 ///
@@ -101,6 +98,8 @@ impl GaussHermite {
 }
 
 impl_node_weight_rule! {GaussHermite, GaussHermiteNodes, GaussHermiteWeights, GaussHermiteIter, GaussHermiteIntoIter}
+
+impl_node_weight_rule_iterators! {GaussHermiteNodes, GaussHermiteWeights, GaussHermiteIter, GaussHermiteIntoIter}
 
 #[cfg(test)]
 mod tests {

--- a/src/jacobi/iterators.rs
+++ b/src/jacobi/iterators.rs
@@ -1,3 +1,0 @@
-//! This module contains the iterators produced by some of the functions on [`GaussJacobi`](super::GaussJacobi).
-
-crate::impl_node_weight_rule_iterators! {GaussJacobiNodes, GaussJacobiWeights, GaussJacobiIter, GaussJacobiIntoIter}

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -18,11 +18,8 @@
 //! assert_abs_diff_eq!(integral, -0.4207987746500829, epsilon = 1e-14);
 //! ```
 
-pub mod iterators;
-use iterators::{GaussJacobiIntoIter, GaussJacobiIter, GaussJacobiNodes, GaussJacobiWeights};
-
 use crate::gamma::gamma;
-use crate::{impl_node_weight_rule, DMatrixf64, Node, Weight};
+use crate::{impl_node_weight_rule, impl_node_weight_rule_iterators, DMatrixf64, Node, Weight};
 
 /// A Gauss-Jacobi quadrature scheme.
 ///
@@ -165,6 +162,8 @@ impl GaussJacobi {
 }
 
 impl_node_weight_rule! {GaussJacobi, GaussJacobiNodes, GaussJacobiWeights, GaussJacobiIter, GaussJacobiIntoIter}
+
+impl_node_weight_rule_iterators! {GaussJacobiNodes, GaussJacobiWeights, GaussJacobiIter, GaussJacobiIntoIter}
 
 #[cfg(test)]
 mod tests {

--- a/src/laguerre/iterators.rs
+++ b/src/laguerre/iterators.rs
@@ -1,3 +1,0 @@
-//! This module contains the iterators produced by some of the functions on [`GaussLaguerre`](super::GaussLaguerre).
-
-crate::impl_node_weight_rule_iterators! {GaussLaguerreNodes, GaussLaguerreWeights, GaussLaguerreIter, GaussLaguerreIntoIter}

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -14,13 +14,8 @@
 //! assert_abs_diff_eq!(integral, 6.0, epsilon = 1e-14);
 //! ```
 
-pub mod iterators;
-use iterators::{
-    GaussLaguerreIntoIter, GaussLaguerreIter, GaussLaguerreNodes, GaussLaguerreWeights,
-};
-
 use crate::gamma::gamma;
-use crate::{impl_node_weight_rule, DMatrixf64, Node, Weight};
+use crate::{impl_node_weight_rule, impl_node_weight_rule_iterators, DMatrixf64, Node, Weight};
 
 /// A Gauss-Laguerre quadrature scheme.
 ///
@@ -132,6 +127,8 @@ impl GaussLaguerre {
 }
 
 impl_node_weight_rule! {GaussLaguerre, GaussLaguerreNodes, GaussLaguerreWeights, GaussLaguerreIter, GaussLaguerreIntoIter}
+
+impl_node_weight_rule_iterators! {GaussLaguerreNodes, GaussLaguerreWeights, GaussLaguerreIter, GaussLaguerreIntoIter}
 
 #[cfg(test)]
 mod tests {

--- a/src/legendre/iterators.rs
+++ b/src/legendre/iterators.rs
@@ -1,3 +1,0 @@
-//! This module contains the iterators produced by some of the functions on [`GaussLegendre`](super::GaussLegendre).
-
-crate::impl_node_weight_rule_iterators! {GaussLegendreNodes, GaussLegendreWeights, GaussLegendreIter, GaussLegendreIntoIter}

--- a/src/legendre/mod.rs
+++ b/src/legendre/mod.rs
@@ -23,14 +23,9 @@
 
 mod bogaert;
 
-pub mod iterators;
-use iterators::{
-    GaussLegendreIntoIter, GaussLegendreIter, GaussLegendreNodes, GaussLegendreWeights,
-};
-
 use bogaert::NodeWeightPair;
 
-use crate::{impl_node_weight_rule, Node, Weight};
+use crate::{impl_node_weight_rule, impl_node_weight_rule_iterators, Node, Weight};
 
 /// A Gauss-Legendre quadrature scheme.
 ///
@@ -108,6 +103,8 @@ impl GaussLegendre {
 }
 
 impl_node_weight_rule! {GaussLegendre, GaussLegendreNodes, GaussLegendreWeights, GaussLegendreIter, GaussLegendreIntoIter}
+
+impl_node_weight_rule_iterators! {GaussLegendreNodes, GaussLegendreWeights, GaussLegendreIter, GaussLegendreIntoIter}
 
 #[cfg(test)]
 mod tests {

--- a/src/midpoint/iterators.rs
+++ b/src/midpoint/iterators.rs
@@ -1,6 +1,0 @@
-//! This crate contains the implementation of the iterators that
-//! can be returned by method calls on a [`Midpoint`](super::Midpoint) instance.
-
-use crate::impl_node_rule_iterators;
-
-impl_node_rule_iterators! {MidpointIter, MidpointIntoIter}

--- a/src/midpoint/mod.rs
+++ b/src/midpoint/mod.rs
@@ -40,10 +40,7 @@
 //! assert_abs_diff_eq!(0.135257, piecewise, epsilon = eps);
 //! ```
 
-pub mod iterators;
-
-use crate::{impl_node_rule_trait, Node};
-use iterators::{MidpointIntoIter, MidpointIter};
+use crate::{impl_node_rule_iterators, impl_node_rule_trait, Node};
 
 /// A midpoint rule quadrature scheme.
 /// ```
@@ -96,6 +93,8 @@ impl Midpoint {
 }
 
 impl_node_rule_trait! {Midpoint, MidpointIter, MidpointIntoIter}
+
+impl_node_rule_iterators! {MidpointIter, MidpointIntoIter}
 
 #[cfg(test)]
 mod tests {

--- a/src/midpoint/mod.rs
+++ b/src/midpoint/mod.rs
@@ -41,7 +41,7 @@
 //! # Ok::<(), MidpointError>(())
 //! ```
 
-use crate::{impl_node_rule_iterators, impl_node_rule_trait, Node};
+use crate::{impl_node_rule_iterators, impl_node_rule, Node};
 
 /// A midpoint rule quadrature scheme.
 /// ```
@@ -95,9 +95,7 @@ impl Midpoint {
     }
 }
 
-impl_node_rule_trait! {Midpoint, MidpointIter, MidpointIntoIter}
-
-impl_node_rule_iterators! {MidpointIter, MidpointIntoIter}
+impl_node_rule! {Midpoint, MidpointIter, MidpointIntoIter}
 
 /// The error returned by [`Midpoint::new`] if given a degree of 0.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/simpson/iterators.rs
+++ b/src/simpson/iterators.rs
@@ -1,6 +1,0 @@
-//! This module contains the implementation of the iterators that
-//! can be returned by method calls on a [`Simpson`](super::Simpson) instance.
-
-use crate::impl_node_rule_iterators;
-
-impl_node_rule_iterators! {SimpsonIter, SimpsonIntoIter}

--- a/src/simpson/mod.rs
+++ b/src/simpson/mod.rs
@@ -33,10 +33,7 @@
 //!
 //! ```
 
-pub mod iterators;
-
-use crate::{impl_node_rule_trait, Node};
-use iterators::{SimpsonIntoIter, SimpsonIter};
+use crate::{impl_node_rule_iterators, impl_node_rule_trait, Node};
 
 /// A Simpson rule quadrature scheme.
 /// ```
@@ -104,6 +101,8 @@ impl Simpson {
 }
 
 impl_node_rule_trait! {Simpson, SimpsonIter, SimpsonIntoIter}
+
+impl_node_rule_iterators! {SimpsonIter, SimpsonIntoIter}
 
 #[cfg(test)]
 mod tests {

--- a/src/simpson/mod.rs
+++ b/src/simpson/mod.rs
@@ -34,7 +34,7 @@
 //! # Ok::<(), SimpsonError>(())
 //! ```
 
-use crate::{impl_node_rule_iterators, impl_node_rule_trait, Node};
+use crate::{impl_node_rule_iterators, impl_node_rule, Node};
 
 /// A Simpson rule quadrature scheme.
 /// ```
@@ -104,9 +104,7 @@ impl Simpson {
     }
 }
 
-impl_node_rule_trait! {Simpson, SimpsonIter, SimpsonIntoIter}
-
-impl_node_rule_iterators! {SimpsonIter, SimpsonIntoIter}
+impl_node_rule! {Simpson, SimpsonIter, SimpsonIntoIter}
 
 /// The error returned by [`Simpson::new`] if given a degree of 0.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]


### PR DESCRIPTION
This was a thought I had and wanted to run by you. Currently the iterators are defined in their own sub-sub-modules. But since we re-export the actual structs they are visible at the top level of the API and the docs, which means that if a user is looking at the docs of the crate where they can see the quadrature rule structs and wants to look at the iterators they actually have to go down two module levels, which seems a bit unnecessary.

This PR moves the definition of the iterators up one level to make the API less nested.