### PR TITLE
Speed up some methods on the iterators by delegating to builtin slice methods

### DIFF
--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -127,6 +127,26 @@ macro_rules! impl_slice_iterator_newtype_traits {
             fn size_hint(&self) -> (::core::primitive::usize, ::core::option::Option<::core::primitive::usize>) {
                 self.0.size_hint()
             }
+
+            // These methods by default call the `next` method a lot to access data.
+            // This isn't needed in our case, since the data underlying the iterator is
+            // a slice, which has O(1) access to any element. As a result we reimplement them
+            // and just delegate to the inbuilt method.
+
+            #[inline]
+            fn nth(&mut self, index: usize) -> ::core::option::Option<Self::Item> {
+                self.0.nth(index)
+            }
+
+            #[inline]
+            fn count(self) -> ::core::primitive::usize {
+                self.0.count()
+            }
+
+            #[inline]
+            fn last(self) -> ::core::option::Option<Self::Item> {
+                self.0.last()
+            }
         }
 
         impl$(<$a>)? ::core::iter::DoubleEndedIterator for $iterator$(<$a>)? {


### PR DESCRIPTION
When you use the `nth(i)` function on an iterator it will call the `next` method `i + 1` times by default.  
Since for our iterators the underlying data is often a slice, which is contiguous in memory that is not needed. It can be sped up by just incrementing the index that's being accessed. 
This PR manually implements this method, as well as `count` and `last` by delegating to the already existing implementation in the standard library (`std::slice::Iter`) that does simplifications like this.

This shortens the final assembly of these methods, see the effect on e.g. `count` here: https://godbolt.org/z/vxvsGEqaG.