### PR TITLE
 Implement the `nth_back` function for the iterators in terms of the already optimized version in the standard library

### DIFF
--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -155,6 +155,11 @@ macro_rules! impl_slice_iterator_newtype_traits {
             fn next_back(&mut self) -> ::core::option::Option<Self::Item> {
                 self.0.next_back()
             }
+
+            #[inline]
+            fn nth_back(&mut self, n: ::core::primitive::usize) -> ::core::option::Option<Self::Item> {
+                self.0.nth_back(n)
+            }
         }
 
         impl$(<$a>)? ::core::iter::ExactSizeIterator for $iterator$(<$a>)? {


### PR DESCRIPTION
Adds the `nth_back` function to the list of functions implemented in #63.

[Compare the massive assembly of `nth_back_derived` which uses the default implementation, with the short assembly of `nth_back_delegated` which uses the specialized implementation here](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DEArgoKkl9ZATwDKjdAGFUtEywYhJAdlKOAMngMmABy7gBGmMQgAEykAA6oCoR2DC5uHl6%2Bicm2AoHBYSyR0XFWmDapQgRMxATp7p4%2BlpjWeQzVtQQFoRFRsZY1dQ2ZzeZdPUUlsQCUlqgmxMjsHAD06wDUACoIeAob5qY2GwDudLQbCEwAbpgbBAh3WFRMJrQEG4IIAPrhTMgAaw2VBMDEqAg2WGIeFu6A24QAnvdHvdiExCAA6ACkGgAgocTMcALIIgCSBCiWIAzE4wBwmNTsBA0MR2CAFLQ8MsQCByZSaXSmKQNngqTFGTNqQAhHG42XrVbbXb7AnHM60C5XW4igh0/Z4FjxehsQRMdobVBUT4PX7/IFYejAM2YOFEZF3cYMdC1OGc8Jo4gI7F41UfEl84jigX0xnMkhsjlctkR6m0%2BnC0VR7CSqkyvGy%2BImcLAhjWn5/QHfKEwl0Qa4gDZYmIANixAFYpZn2wARYWeDZmPAAL0wMw2AFpGRsAPLxdqppvNrtU7CN7x53EbLcbcMU4h1jGEKIQGYzDFfW2AiAMSX57zd2UFoslsuXgFV1qYJ0U9B1huL9tOzFHs%2BwbQcRzHScVxnOdUgXFtl1XLF11lbcdzJPcYgPI991Pc8bQrAFr1vOV70fPEDSNVNBSnCMzRIYEGN3fk0wZaDkI3NCCAReI7j5FhGypbtGxbQURWA3NUO3KhS2CVQCAgRcWBMD4rCoSCp1necaSEVoqB5fipw4qS0K3NSMQ0c9MHkk8TLXB87wcuUKMNWhqJjaDuwWcJ6GwL0XToohiEY4LmOIdy2KQlC8TQmTPmsgg30UltlNUvSNOgrS4J0vSDIpFgjOizdTLMvSLKs%2BSkpItDkKc2ryNxSi3OjSKNkChj%2BFCjCoijVjCs47duN4tr8sE4TFzE5cBq3OK5IUpSVIOdKJ002CBFTXTaH03l8v6uy0PMyy5tsmLt3qxyGqaiKpy8otfP89B2uCzr0IjXqaPYorYtkhKkoWtKtoy1csvWnKtryzACs%2B6bTMOirEsIk7iq3c7nORl8L0R/6lq20CB2SCCVsytaGA23KdshvbTpKuHMbtYi7NR2qODmWhODbXhPG4XhUE4AAlMxVIWJY7ibKkeFIAhNBZuYARANtLJbLgAA5m0kSQ1ZiKkqWbLh9E4SROel0heY4XgFBADRJeluY4FgJA0ENOgonIShHfiZ3omILhvGVq2aHeKILYgcJOAl8IglqBEw94CPmEDadwm0Cope50hHZNAhpwYWho7TrBwhMYAnDEWgLfzyHDGAcQOC0Uh8FZSpbnLuvrIqFSVgloIKTZ2veD9AMERcLAY8l6EWFH25iHCJJMG7SujE5Iwbb4AxgAUAA1PBMBOWdGFH/hBBEMR2CkGRBEUFR1D70hdD1gxl9Mcx9DwcILcgOZUBJ8vx2nHmp%2BhFgd%2BJ4WhtFSA4L0IxPB6wCEEXoxR%2Bh6xyCkAQUC9DIPaJMPo0Q9blHBB0IY9RXCND0Hg9onQ6hYIQTgwYXQ0G4MIVQ6YXA5gKGFtyFh%2BsOAc1IFzOupsNhPwIMgDYXAMS%2BwshsCAuBCAMTFiw3gqctCnlIHLSQABOcRVJlZcCpG2NsejvDNmbFSdRzYuGG1IBPLgGhLK2PsQ4hxes%2BE804ObS21s%2B4qN7jEI2N9TaKJtnMKeyR7CSCAA%3D%3D).