### PR TITLE
Add rust syntax highlighting to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ using Gaussian quadrature.
 
 To use the crate, the desired quadrature rule has to be included in the program, e.g. for a Gauss-Legendre rule
 
-```
+```rust
  use gauss_quad::GaussLegendre;
 ```
 
 The general call structure is to first initialize the n-point quadrature rule setting the degree n via
 
-```
+```rust
  let quad = QUADRATURE_RULE::init(n);
 ```
 
@@ -35,25 +35,25 @@ where QUADRATURE_RULE can currently be set to calculate either:
 
 For the quadrature rules that take an additional parameter, such as Gauss-Laguerre and Gauss-Jacobi, the parameters have to be added to the initialization, e.g.
 
-```
+```rust
  let quad = GaussLaguerre::init(n, alpha);
 ```
 
 Then to calculate the integral of a function call
 
-```
+```rust
 let integral = quad.integrate(a, b, f(x));
 ```
 
 where a and b (both f64) are the integral bounds and the f(x) the integrand (fn(f64) -> f64).
 For example to integrate a parabola from 0..1 one can use a lambda expression as integrand and call:
 
-```
+```rust
 let integral = quad.integrate(0.0, 1.0, |x| x*x);
 ```
 
 If the integral is improper, as in the case of Gauss-Laguerre and Gauss-Hermite integrals, no integral bounds should be passed and the call simplifies to
 
-```
+```rust
 let integral = quad.integrate(f(x));
 ```


### PR DESCRIPTION
This adds syntax highlighting to the  README for clarity.