### PR TITLE
Fix email toml format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gauss-quad"
 version = "0.1.9"
-authors = ["DomiDre <dominiquedresen@gmail.com>", "Johanna Sörngård (jsorngard@gmail.com)"]
+authors = ["DomiDre <dominiquedresen@gmail.com>", "Johanna Sörngård <jsorngard@gmail.com>"]
 keywords = ["gaussian", "quadrature", "numerics", "integration"]
 categories = ["mathematics"]
 edition = "2018"


### PR DESCRIPTION
I just realized that my email link in `Cargo.toml` doesn't use the standard TOML formatting with angle brackets, so this PR just fixes that.