### PR TITLE
Write the time complexity more clearly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,7 @@
 //! # Ok::<(), GaussLegendreError>(())
 //! ```
 //! However, the time complexity of the integration then scales with the number of nodes to
-//! the power of the depth of the integral, e.g. O(n^(3)) for triple integrals.
+//! the power of the depth of the integral, e.g. O(n³) for triple integrals.
 //!
 //! ## Feature flags
 //!


### PR DESCRIPTION
The way I wrote the time complexity in the multiple-integral example is a bit cluttered. This PR simplifies it by using a [cubed symbol](https://symbolsdb.com/cubed-symbol) instead of writing ^(3).