### PR TITLE
Clarify changes of 0.2.1 in cangelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ This document contains all changes to the crate since version 0.1.8.
 
 # 0.2.1
 
-- Add par_integrate to every method which can be used with the rayon feature to use parallel iterator during integration.
+- Add the function `par_integrate` to every quadrature rule struct which can be used when the `rayon` feature is active to perform the integration in parallel.
 
 # 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ This document contains all changes to the crate since version 0.1.8.
 
 # 0.2.1
 
-- Add the function `par_integrate` to every quadrature rule struct which can be used when the `rayon` feature is active to perform the integration in parallel.
+- Add the function `par_integrate` to every quadrature rule struct which can be used when the `rayon` feature is enabled to perform the integration in parallel.
 
 # 0.2.0
 


### PR DESCRIPTION
This PR clarifies that the `par_integrate` function is added to the quadrature rule structs themselves when the `rayon` feature is enabled. Also makes them items. 