### PR TITLE
Add note about `par_new` to log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ This document contains all changes to the crate since version 0.1.8.
 # 0.2.1
 
 - Add the function `par_integrate` to every quadrature rule struct which can be used when the `rayon` feature is enabled to perform the integration in parallel.
+- Add the function `par_new` to `GaussLegendre` to initialize it in parallel. This function is also behind the `rayon` feature.
 
 # 0.2.0
 


### PR DESCRIPTION
Add a note to the log about the addition of the `par_new` function to `GaussLegendre`. 