### PR TITLE
Add information about what degree of quadrature rule is needed to the documentation of each rules `new` function

### DIFF
--- a/src/hermite/mod.rs
+++ b/src/hermite/mod.rs
@@ -58,6 +58,8 @@ pub struct GaussHermite {
 impl GaussHermite {
     /// Initializes Gauss-Hermite quadrature rule of the given degree by computing the needed nodes and weights.
     ///
+    /// A rule of degree `n` can integrate polynomials of degree 2`n`-1 exactly.
+    ///
     /// Applies the Golub-Welsch algorithm to determine Gauss-Hermite nodes & weights.
     /// Constructs the companion matrix A for the Hermite Polynomial using the relation:
     /// 1/2 H_{n+1} + n H_{n-1} = x H_n

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -60,6 +60,8 @@ impl GaussJacobi {
     /// needed for the given parameters. `alpha` is the exponent of the (1 - x) factor and `beta` is the
     /// exponent of the (1 + x) factor.
     ///
+    /// A rule of degree `n` can integrate polynomials of degree 2`n`-1 exactly.
+    ///
     /// Applies the Golub-Welsch algorithm to determine Gauss-Jacobi nodes & weights.
     /// See Gil, Segura, Temme - Numerical Methods for Special Functions
     ///

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -57,6 +57,8 @@ impl GaussLaguerre {
     /// Initializes Gauss-Laguerre quadrature rule of the given degree by computing the nodes and weights
     /// needed for the given `alpha` parameter.
     ///
+    /// A rule of degree `n` can integrate polynomials of degree 2`n`-1 exactly.
+    ///
     /// Applies the Golub-Welsch algorithm to determine Gauss-Laguerre nodes & weights.
     /// Constructs the companion matrix A for the Laguerre Polynomial using the relation:
     /// -n L_{n-1} + (2n+1) L_{n} -(n+1) L_{n+1} = x L_n

--- a/src/legendre/mod.rs
+++ b/src/legendre/mod.rs
@@ -73,7 +73,8 @@ pub struct GaussLegendre {
 
 impl GaussLegendre {
     /// Initializes a Gauss-Legendre quadrature rule of the given degree by computing the needed nodes and weights.  
-    /// A rule of degree `n` can integrate a polynomial of degree 2`n`-1 exactly.
+    /// 
+    /// A rule of degree `n` can integrate polynomials of degree 2`n`-1 exactly.
     ///
     /// Uses the [algorithm by Ignace Bogaert](https://doi.org/10.1137/140954969), which has linear time
     /// complexity.

--- a/src/legendre/mod.rs
+++ b/src/legendre/mod.rs
@@ -72,7 +72,8 @@ pub struct GaussLegendre {
 }
 
 impl GaussLegendre {
-    /// Initializes a Gauss-Legendre quadrature rule of the given degree by computing the needed nodes and weights.
+    /// Initializes a Gauss-Legendre quadrature rule of the given degree by computing the needed nodes and weights.  
+    /// A rule of degree `n` can integrate a polynomial of degree 2`n`-1 exactly.
     ///
     /// Uses the [algorithm by Ignace Bogaert](https://doi.org/10.1137/140954969), which has linear time
     /// complexity.


### PR DESCRIPTION
This way the user of the library has that information directly available when they have to supply the `deg` parameter.