### PR TITLE
Simplify the error generation code and separate the backtrace generation into the error structs every time

### DIFF
--- a/src/hermite/mod.rs
+++ b/src/hermite/mod.rs
@@ -74,7 +74,7 @@ impl GaussHermite {
     /// Returns an error if `deg` is smaller than 2.
     pub fn new(deg: usize) -> Result<Self, GaussHermiteError> {
         if deg < 2 {
-            return Err(GaussHermiteError(Backtrace::capture()));
+            return Err(GaussHermiteError::new());
         }
         let mut companion_matrix = DMatrixf64::from_element(deg, deg, 0.0);
         // Initialize symmetric companion matrix
@@ -154,6 +154,11 @@ impl fmt::Display for GaussHermiteError {
 impl std::error::Error for GaussHermiteError {}
 
 impl GaussHermiteError {
+    /// Calls [`Backtrace::capture`] and wraps the result in a `GaussHermiteError` struct.
+    fn new() -> Self {
+        Self(Backtrace::capture())
+    }
+
     /// Returns a [`Backtrace`] to where the error was created.
     ///
     /// This backtrace is captured with [`Backtrace::capture`], see it for more information about how to make it display information when printed.

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -74,29 +74,16 @@ impl GaussJacobi {
             (alpha.is_finite() && alpha > -1.0),
             (beta.is_finite() && beta > -1.0),
         ) {
-            (true, true, true) => (),
-            (false, true, true) => {
-                return Err(GaussJacobiError::new(GaussJacobiErrorReason::Degree))
-            }
-            (true, false, true) => {
-                return Err(GaussJacobiError::new(GaussJacobiErrorReason::Alpha))
-            }
-            (true, true, false) => return Err(GaussJacobiError::new(GaussJacobiErrorReason::Beta)),
-            (true, false, false) => {
-                return Err(GaussJacobiError::new(GaussJacobiErrorReason::AlphaBeta))
-            }
-            (false, false, true) => {
-                return Err(GaussJacobiError::new(GaussJacobiErrorReason::DegreeAlpha))
-            }
-            (false, true, false) => {
-                return Err(GaussJacobiError::new(GaussJacobiErrorReason::DegreeBeta))
-            }
-            (false, false, false) => {
-                return Err(GaussJacobiError::new(
-                    GaussJacobiErrorReason::DegreeAlphaBeta,
-                ))
-            }
-        };
+            (true, true, true) => Ok(()),
+            (false, true, true) => Err(GaussJacobiErrorReason::Degree),
+            (true, false, true) => Err(GaussJacobiErrorReason::Alpha),
+            (true, true, false) => Err(GaussJacobiErrorReason::Beta),
+            (true, false, false) => Err(GaussJacobiErrorReason::AlphaBeta),
+            (false, false, true) => Err(GaussJacobiErrorReason::DegreeAlpha),
+            (false, true, false) => Err(GaussJacobiErrorReason::DegreeBeta),
+            (false, false, false) => Err(GaussJacobiErrorReason::DegreeAlphaBeta),
+        }
+        .map_err(|reason| GaussJacobiError::new(reason))?;
 
         let mut companion_matrix = DMatrixf64::from_element(deg, deg, 0.0);
 

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -73,12 +73,11 @@ impl GaussLaguerre {
     pub fn new(deg: usize, alpha: f64) -> Result<Self, GaussLaguerreError> {
         match (deg >= 2, (alpha.is_finite() && alpha > -1.0)) {
             (true, true) => Ok(()),
-            (false, true) => Err(GaussLaguerreError::new(GaussLaguerreErrorReason::Degree)),
-            (true, false) => Err(GaussLaguerreError::new(GaussLaguerreErrorReason::Alpha)),
-            (false, false) => Err(GaussLaguerreError::new(
-                GaussLaguerreErrorReason::DegreeAlpha,
-            )),
-        }?;
+            (false, true) => Err(GaussLaguerreErrorReason::Degree),
+            (true, false) => Err(GaussLaguerreErrorReason::Alpha),
+            (false, false) => Err(GaussLaguerreErrorReason::DegreeAlpha),
+        }
+        .map_err(|reason| GaussLaguerreError::new(reason))?;
 
         let mut companion_matrix = DMatrixf64::from_element(deg, deg, 0.0);
 

--- a/src/legendre/mod.rs
+++ b/src/legendre/mod.rs
@@ -84,7 +84,7 @@ impl GaussLegendre {
     /// Returns an error if `deg` is smaller than 2.
     pub fn new(deg: usize) -> Result<Self, GaussLegendreError> {
         if deg < 2 {
-            return Err(GaussLegendreError(Backtrace::capture()));
+            return Err(GaussLegendreError::new());
         }
 
         Ok(Self {
@@ -102,7 +102,7 @@ impl GaussLegendre {
     /// Returns an error if `deg` is smaller than 2.
     pub fn par_new(deg: usize) -> Result<Self, GaussLegendreError> {
         if deg < 2 {
-            return Err(GaussLegendreError(Backtrace::capture()));
+            return Err(GaussLegendreError::new());
         }
 
         Ok(Self {
@@ -190,6 +190,11 @@ impl fmt::Display for GaussLegendreError {
 }
 
 impl GaussLegendreError {
+    /// Calls [`Backtrace::capture`] and wraps the result in a `GaussLegendreError` struct.
+    fn new() -> Self {
+        Self(Backtrace::capture())
+    }
+
     /// Returns a [`Backtrace`] to where the error was created.
     ///
     /// This backtrace is captured with [`Backtrace::capture`], see it for more information about how to make it display information when printed.

--- a/src/midpoint/mod.rs
+++ b/src/midpoint/mod.rs
@@ -79,7 +79,7 @@ impl Midpoint {
                 nodes: (0..degree).map(|d| d as f64).collect(),
             })
         } else {
-            Err(MidpointError(Backtrace::capture()))
+            Err(MidpointError::new())
         }
     }
 
@@ -131,6 +131,11 @@ impl fmt::Display for MidpointError {
 }
 
 impl MidpointError {
+    /// Calls [`Backtrace::capture`] and wraps the result in a `MidpointError` struct.
+    fn new() -> Self {
+        Self(Backtrace::capture())
+    }
+
     /// Returns a [`Backtrace`] to where the error was created.
     ///
     /// This backtrace is captured with [`Backtrace::capture`], see it for more information about how to make it display information when printed.

--- a/src/simpson/mod.rs
+++ b/src/simpson/mod.rs
@@ -70,7 +70,7 @@ impl Simpson {
                 nodes: (0..degree).map(|d| d as f64).collect(),
             })
         } else {
-            Err(SimpsonError(Backtrace::capture()))
+            Err(SimpsonError::new())
         }
     }
 
@@ -155,6 +155,11 @@ impl fmt::Display for SimpsonError {
 }
 
 impl SimpsonError {
+    /// Calls [`Backtrace::capture`] and wraps the result in a `SimpsonError` struct.
+    fn new() -> Self {
+        Self(Backtrace::capture())
+    }
+
     /// Returns a [`Backtrace`] to where the error was created.
     ///
     /// This backtrace is captured with [`Backtrace::capture`], see it for more information about how to make it display information when printed.


### PR DESCRIPTION
This PR cleans up the error code by adding a `new` function that is responsible for capturing a `Backtrace` to the error types that didn't have it, and simplifies and shrinks the error generation code for the ones that did.