### PR TITLE
Make the crate `no_std` compatible?

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,7 @@ version = "0.2.1"
 dependencies = [
  "approx",
  "criterion",
+ "libm",
  "nalgebra",
  "rayon",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.16.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
+checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
 
 [[package]]
 name = "cast"
@@ -256,6 +256,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
+name = "libm"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,9 +269,9 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "matrixmultiply"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7574c1cf36da4798ab73da5b215bbf444f50718207754cb522201d78d1cd0ff2"
+checksum = "9380b911e3e96d10c1f415da0876389aaf1b56759054eeb0de7df940c456ba1a"
 dependencies = [
  "autocfg",
  "rawpointer",
@@ -338,6 +344,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -636,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.25"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2caba658a80831539b30698ae9862a72db6697dfdd7151e46920f5f2755c3ce2"
+checksum = "b828f995bf1e9622031f8009f8481a85406ce1f4d4588ff746d872043e855690"
 dependencies = [
  "bytemuck",
  "safe_arch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ crate-type = ["lib", "cdylib"]
 nalgebra = { version = "0.33", default-features = false, features = ["alloc", "libm"] }
 serde = { version = "1.0.204", default-features = false, features = ["alloc", "derive"], optional = true }
 rayon = { version = "1.10", optional = true }
+libm = "0.2"
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,15 @@ rayon = {version = "1.10", optional = true}
 
 [dev-dependencies]
 approx = "0.5.1"
-criterion = {version = "0.5", features = ["html_reports"]}
+criterion = { version = "0.5", features = ["html_reports"] }
 
 [features]
 # Implements the `Serialize` and `Deserialize` traits from the [`serde`](https://crates.io/crates/serde) crate for the quadrature rule structs.
 serde = ["dep:serde"]
 # Enables a parallel version of the `integrate` function on the quadrature rule structs. Can speed up integration if evaluating the integrand is expensive.
 rayon = ["dep:rayon"]
+# Enables the errors to capture a `Backtrace`. If this feature is disabled the crate is `no_std` compatible.
+std = []
 
 [package.metadata.docs.rs]
 # Document all features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,10 @@ criterion = { version = "0.5", features = ["html_reports"] }
 # Implements the `Serialize` and `Deserialize` traits from the [`serde`](https://crates.io/crates/serde) crate for the quadrature rule structs.
 serde = ["dep:serde"]
 # Enables a parallel version of the `integrate` function on the quadrature rule structs. Can speed up integration if evaluating the integrand is expensive.
+# Note that `rayon` depends on the standard library.
 rayon = ["dep:rayon"]
 # Enables the errors to capture a `Backtrace`. If this feature is disabled the crate is `no_std` compatible.
-std = ["nalgebra/std"]
+std = ["nalgebra/std", "serde/std"]
 
 [package.metadata.docs.rs]
 # Document all features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ repository = "https://github.com/domidre/gauss-quad"
 crate-type = ["lib", "cdylib"]
 
 [dependencies]
-nalgebra = {version = "0.33", default-features = false, features = ["std"]}
-serde = {version = "1.0.204", default-features = false, features = ["alloc", "derive"], optional = true}
-rayon = {version = "1.10", optional = true}
+nalgebra = { version = "0.33", default-features = false, features = ["alloc", "libm"] }
+serde = { version = "1.0.204", default-features = false, features = ["alloc", "derive"], optional = true }
+rayon = { version = "1.10", optional = true }
 
 [dev-dependencies]
 approx = "0.5.1"
@@ -29,7 +29,7 @@ serde = ["dep:serde"]
 # Enables a parallel version of the `integrate` function on the quadrature rule structs. Can speed up integration if evaluating the integrand is expensive.
 rayon = ["dep:rayon"]
 # Enables the errors to capture a `Backtrace`. If this feature is disabled the crate is `no_std` compatible.
-std = []
+std = ["nalgebra/std"]
 
 [package.metadata.docs.rs]
 # Document all features

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -52,7 +52,7 @@ macro_rules! __impl_node_weight_rule {
         // in a way the adheres to the API guidelines: <https://rust-lang.github.io/api-guidelines/naming.html>.
         // The functions in these impl blocks all have an #[inline] directive because they are trivial.
 
-        use crate::data_api::{PortableVec, PortableVecIntoIter};
+        use $crate::data_api::{PortableVec, PortableVecIntoIter};
 
         // Lets the user do
         // for (node, weight) in QuadratuleRule::new(...) {
@@ -334,7 +334,7 @@ macro_rules! __impl_slice_iterator_newtype_traits {
 #[doc(hidden)]
 macro_rules! __impl_node_rule {
     ($quadrature_rule:ident, $quadrature_rule_iter:ident, $quadrature_rule_into_iter:ident) => {
-        use crate::data_api::PortableVecIntoIter;
+        use $crate::data_api::PortableVecIntoIter;
 
         // Lets the user do
         // for node in QuadratureRule::new(...) {

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -16,6 +16,8 @@ pub type Node = f64;
 /// A weight in a quadrature rule.
 pub type Weight = f64;
 
+// These types are used in the macro to guarantee that we point to the right `Vec` and `IntoIter`
+// regardless of whether we have the standard library.
 #[cfg(feature = "std")]
 pub(crate) type PortableVec<T> = ::std::vec::Vec<T>;
 #[cfg(not(feature = "std"))]

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -16,6 +16,16 @@ pub type Node = f64;
 /// A weight in a quadrature rule.
 pub type Weight = f64;
 
+#[cfg(feature = "std")]
+pub(crate) type PortableVec<T> = ::std::vec::Vec<T>;
+#[cfg(not(feature = "std"))]
+pub(crate) type PortableVec<T> = ::alloc::vec::Vec<T>;
+
+#[cfg(feature = "std")]
+pub(crate) type PortableVecIntoIter<T> = ::std::vec::IntoIter<T>;
+#[cfg(not(feature = "std"))]
+pub(crate) type PortableVecIntoIter<T> = ::alloc::vec::IntoIter<T>;
+
 /// This macro implements the data access API for the given quadrature rule struct that contains
 /// a field named `node_weight_pairs` of the type `Vec<(Node, Weight)>`.
 /// It takes in the name of the quadrature rule struct as well as the names it should give the iterators
@@ -39,6 +49,8 @@ macro_rules! __impl_node_weight_rule {
         // Implements functions for accessing the underlying data of the quadrature rule struct
         // in a way the adheres to the API guidelines: <https://rust-lang.github.io/api-guidelines/naming.html>.
         // The functions in these impl blocks all have an #[inline] directive because they are trivial.
+
+        use crate::data_api::{PortableVec, PortableVecIntoIter};
 
         // Lets the user do
         // for (node, weight) in QuadratuleRule::new(...) {
@@ -98,7 +110,7 @@ macro_rules! __impl_node_weight_rule {
             /// This function just returns the underlying vector without any computation or cloning.
             #[inline]
             #[must_use = "`self` will be dropped if the result is not used"]
-            pub fn into_node_weight_pairs(self) -> ::std::vec::Vec<($crate::Node, $crate::Weight)> {
+            pub fn into_node_weight_pairs(self) -> PortableVec<($crate::Node, $crate::Weight)> {
                 self.node_weight_pairs
             }
 
@@ -117,7 +129,7 @@ macro_rules! __impl_node_weight_rule {
         pub struct $quadrature_rule_nodes<'a>(
             // This horrible type is just the fully qualified path of the type returned
             // by `slice.iter().map(|(x, _)| x)`.
-            ::std::iter::Map<
+            ::core::iter::Map<
                 ::core::slice::Iter<'a, ($crate::Node, $crate::Weight)>,
                 fn(&'a ($crate::Node, $crate::Weight)) -> &'a $crate::Node,
             >,
@@ -126,7 +138,7 @@ macro_rules! __impl_node_weight_rule {
         impl<'a> $quadrature_rule_nodes<'a> {
             #[inline]
             const fn new(
-                iter_map: ::std::iter::Map<
+                iter_map: ::core::iter::Map<
                     ::core::slice::Iter<'a, ($crate::Node, $crate::Weight)>,
                     fn(&'a ($crate::Node, $crate::Weight)) -> &'a $crate::Node,
                 >,
@@ -146,7 +158,7 @@ macro_rules! __impl_node_weight_rule {
         #[must_use = "iterators are lazy and do nothing unless consumed"]
         pub struct $quadrature_rule_weights<'a>(
             // Same as the previous horrible type, but maps out the weight instead of the node.
-            ::std::iter::Map<
+            ::core::iter::Map<
                 ::core::slice::Iter<'a, ($crate::Node, $crate::Weight)>,
                 fn(&'a ($crate::Node, $crate::Weight)) -> &'a $crate::Weight,
             >,
@@ -155,7 +167,7 @@ macro_rules! __impl_node_weight_rule {
         impl<'a> $quadrature_rule_weights<'a> {
             #[inline]
             const fn new(
-                iter_map: ::std::iter::Map<
+                iter_map: ::core::iter::Map<
                     ::core::slice::Iter<'a, ($crate::Node, $crate::Weight)>,
                     fn(&'a ($crate::Node, $crate::Weight)) -> &'a $crate::Weight,
                 >,
@@ -216,12 +228,12 @@ macro_rules! __impl_node_weight_rule {
         /// Created by the [`IntoIterator`] trait implementation of the quadrature rule struct.
         #[derive(::core::fmt::Debug, ::core::clone::Clone)]
         #[must_use = "iterators are lazy and do nothing unless consumed"]
-        pub struct $quadrature_rule_into_iter(::std::vec::IntoIter<($crate::Node, $crate::Weight)>);
+        pub struct $quadrature_rule_into_iter(PortableVecIntoIter<($crate::Node, $crate::Weight)>);
 
         impl $quadrature_rule_into_iter {
             #[inline]
             const fn new(
-                node_weight_pairs: ::std::vec::IntoIter<($crate::Node, $crate::Weight)>,
+                node_weight_pairs: PortableVecIntoIter<($crate::Node, $crate::Weight)>,
             ) -> Self {
                 Self(node_weight_pairs)
             }
@@ -320,6 +332,8 @@ macro_rules! __impl_slice_iterator_newtype_traits {
 #[doc(hidden)]
 macro_rules! __impl_node_rule {
     ($quadrature_rule:ident, $quadrature_rule_iter:ident, $quadrature_rule_into_iter:ident) => {
+        use crate::data_api::PortableVecIntoIter;
+
         // Lets the user do
         // for node in QuadratureRule::new(...) {
         //    ...
@@ -417,11 +431,11 @@ macro_rules! __impl_node_rule {
         /// Created by the [`IntoIterator`] trait implementation of the rule struct.
         #[derive(::core::fmt::Debug, ::core::clone::Clone)]
         #[must_use = "iterators are lazy and do nothing unless consumed"]
-        pub struct $quadrature_rule_into_iter(::std::vec::IntoIter<$crate::Node>);
+        pub struct $quadrature_rule_into_iter(PortableVecIntoIter<$crate::Node>);
 
         impl $quadrature_rule_into_iter {
             #[inline]
-            const fn new(iter: ::std::vec::IntoIter<$crate::Node>) -> Self {
+            const fn new(iter: PortableVecIntoIter<$crate::Node>) -> Self {
                 Self(iter)
             }
 
@@ -450,7 +464,10 @@ macro_rules! __impl_node_rule {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(not(feature = "std"))]
+    use alloc::vec::Vec;
     use core::fmt;
+    #[cfg(feature = "std")]
     use std::backtrace::Backtrace;
 
     #[derive(Debug, Clone, PartialEq)]
@@ -460,11 +477,15 @@ mod tests {
     }
 
     #[derive(Debug)]
-    pub struct MockQuadratureError(Backtrace);
+    pub struct MockQuadratureError {
+        #[cfg(feature = "std")]
+        backtrace: Backtrace,
+    }
 
+    #[cfg(feature = "std")]
     impl MockQuadratureError {
         pub fn backtrace(&self) -> &Backtrace {
-            &self.0
+            &self.backtrace
         }
     }
 
@@ -474,12 +495,15 @@ mod tests {
         }
     }
 
-    impl std::error::Error for MockQuadratureError {}
+    impl core::error::Error for MockQuadratureError {}
 
     impl MockQuadrature {
         pub fn new(deg: usize) -> Result<Self, MockQuadratureError> {
             if deg < 1 {
-                return Err(MockQuadratureError(Backtrace::capture()));
+                return Err(MockQuadratureError {
+                    #[cfg(feature = "std")]
+                    backtrace: Backtrace::capture(),
+                });
             }
 
             Ok(Self {

--- a/src/elementary.rs
+++ b/src/elementary.rs
@@ -1,0 +1,43 @@
+pub(crate) fn sin(x: f64) -> f64 {
+    #[cfg(feature = "std")]
+    {
+        x.sin()
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        libm::sin(x)
+    }
+}
+
+pub(crate) fn cos(x: f64) -> f64 {
+    #[cfg(feature = "std")]
+    {
+        x.cos()
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        libm::cos(x)
+    }
+}
+
+pub(crate) fn sqrt(x: f64) -> f64 {
+    #[cfg(feature = "std")]
+    {
+        x.sqrt()
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        libm::sqrt(x)
+    }
+}
+
+pub(crate) fn pow(base: f64, exp: f64) -> f64 {
+    #[cfg(feature = "std")]
+    {
+        base.powf(exp)
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        libm::pow(base, exp)
+    }
+}

--- a/src/gamma.rs
+++ b/src/gamma.rs
@@ -5,6 +5,8 @@
 
 use core::f64::consts::{E, PI};
 
+use crate::elementary::{pow, sin};
+
 /// Constant value for `2 * sqrt(e / pi)`
 const TWO_SQRT_E_OVER_PI: f64 = 1.860_382_734_205_265_7;
 
@@ -38,7 +40,7 @@ pub(crate) fn gamma(x: f64) -> f64 {
             .skip(1)
             .fold(GAMMA_DK[0], |s, t| s + t.1 / (t.0 as f64 - x));
 
-        PI / ((PI * x).sin() * s * TWO_SQRT_E_OVER_PI * ((0.5 - x + GAMMA_R) / E).powf(0.5 - x))
+        PI / (sin(PI * x) * s * TWO_SQRT_E_OVER_PI * pow((0.5 - x + GAMMA_R) / E, 0.5 - x))
     } else {
         let s = GAMMA_DK
             .iter()
@@ -46,7 +48,7 @@ pub(crate) fn gamma(x: f64) -> f64 {
             .skip(1)
             .fold(GAMMA_DK[0], |s, t| s + t.1 / (x + t.0 as f64 - 1.0));
 
-        s * TWO_SQRT_E_OVER_PI * ((x - 0.5 + GAMMA_R) / E).powf(x - 0.5)
+        s * TWO_SQRT_E_OVER_PI * pow((x - 0.5 + GAMMA_R) / E, x - 0.5)
     }
 }
 

--- a/src/hermite/mod.rs
+++ b/src/hermite/mod.rs
@@ -23,7 +23,7 @@
 #[cfg(feature = "rayon")]
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 
-use crate::{DMatrixf64, Node, Weight, __impl_node_weight_rule};
+use crate::{DMatrixf64, Node, Weight, __impl_node_weight_rule, elementary::sqrt};
 
 use core::f64::consts::PI;
 
@@ -84,7 +84,7 @@ impl GaussHermite {
         // Initialize symmetric companion matrix
         for idx in 0..deg - 1 {
             let idx_f64 = 1.0 + idx as f64;
-            let element = (idx_f64 * 0.5).sqrt();
+            let element = sqrt(idx_f64 * 0.5);
             unsafe {
                 *companion_matrix.get_unchecked_mut((idx, idx + 1)) = element;
                 *companion_matrix.get_unchecked_mut((idx + 1, idx)) = element;
@@ -103,7 +103,7 @@ impl GaussHermite {
                     eigen
                         .eigenvectors
                         .row(0)
-                        .map(|x| x * x * PI.sqrt())
+                        .map(|x| x * x * sqrt(PI))
                         .iter()
                         .copied(),
                 )
@@ -229,7 +229,7 @@ mod tests {
     #[test]
     fn check_iterators() {
         let rule = GaussHermite::new(3).unwrap();
-        let ans = core::f64::consts::PI.sqrt() / 2.0;
+        let ans = sqrt(core::f64::consts::PI) / 2.0;
 
         assert_abs_diff_eq!(
             ans,

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -25,7 +25,11 @@ use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use crate::gamma::gamma;
 use crate::{DMatrixf64, Node, Weight, __impl_node_weight_rule};
 
+#[cfg(feature = "std")]
 use std::backtrace::Backtrace;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
 /// A Gauss-Jacobi quadrature scheme.
 ///
@@ -202,6 +206,7 @@ __impl_node_weight_rule! {GaussJacobi, GaussJacobiNodes, GaussJacobiWeights, Gau
 #[derive(Debug)]
 pub struct GaussJacobiError {
     reason: GaussJacobiErrorReason,
+    #[cfg(feature = "std")]
     backtrace: Backtrace,
 }
 
@@ -211,6 +216,7 @@ impl GaussJacobiError {
     pub(crate) fn new(reason: GaussJacobiErrorReason) -> Self {
         Self {
             reason,
+            #[cfg(feature = "std")]
             backtrace: Backtrace::capture(),
         }
     }
@@ -221,6 +227,7 @@ impl GaussJacobiError {
         self.reason
     }
 
+    #[cfg(feature = "std")]
     /// Returns a [`Backtrace`] to where the error was created.
     ///
     /// This backtrace is captured with [`Backtrace::capture`], see it for more information about how to make it display information when printed.
@@ -253,7 +260,7 @@ impl fmt::Display for GaussJacobiError {
     }
 }
 
-impl std::error::Error for GaussJacobiError {}
+impl core::error::Error for GaussJacobiError {}
 
 /// The reason for the `GaussJacobiError`, returned by the [`GaussJacobiError::reason`] function.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -309,6 +316,9 @@ mod tests {
     use approx::assert_abs_diff_eq;
 
     use super::*;
+
+    #[cfg(not(feature = "std"))]
+    use alloc::format;
 
     #[test]
     fn check_alpha_beta_bounds() {

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -18,6 +18,8 @@
 //! # Ok::<(), GaussLaguerreError>(())
 //! ```
 
+use crate::elementary::sqrt;
+
 #[cfg(feature = "rayon")]
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 
@@ -89,7 +91,7 @@ impl GaussLaguerre {
         // Initialize symmetric companion matrix
         for idx in 0..deg - 1 {
             let idx_f64 = 1.0 + idx as f64;
-            let off_diag = (idx_f64 * (idx_f64 + alpha)).sqrt();
+            let off_diag = sqrt(idx_f64 * (idx_f64 + alpha));
             unsafe {
                 *companion_matrix.get_unchecked_mut((idx, idx)) = diag;
                 *companion_matrix.get_unchecked_mut((idx, idx + 1)) = off_diag;

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -24,7 +24,11 @@ use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use crate::gamma::gamma;
 use crate::{DMatrixf64, Node, Weight, __impl_node_weight_rule};
 
+#[cfg(feature = "std")]
 use std::backtrace::Backtrace;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
 /// A Gauss-Laguerre quadrature scheme.
 ///
@@ -162,6 +166,7 @@ __impl_node_weight_rule! {GaussLaguerre, GaussLaguerreNodes, GaussLaguerreWeight
 #[derive(Debug)]
 pub struct GaussLaguerreError {
     reason: GaussLaguerreErrorReason,
+    #[cfg(feature = "std")]
     backtrace: Backtrace,
 }
 
@@ -184,6 +189,7 @@ impl GaussLaguerreError {
     pub(crate) fn new(reason: GaussLaguerreErrorReason) -> Self {
         Self {
             reason,
+            #[cfg(feature = "std")]
             backtrace: Backtrace::capture(),
         }
     }
@@ -194,6 +200,7 @@ impl GaussLaguerreError {
         self.reason
     }
 
+    #[cfg(feature = "std")]
     /// Returns a [`Backtrace`] to where the error was created.
     ///
     /// This backtrace is captured with [`Backtrace::capture`], see it for more information about how to make it display information when printed.
@@ -203,7 +210,7 @@ impl GaussLaguerreError {
     }
 }
 
-impl std::error::Error for GaussLaguerreError {}
+impl core::error::Error for GaussLaguerreError {}
 
 /// The reason for the `GaussLaguerreError`, returned by the [`GaussLaguerreError::reason`] function.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -236,6 +243,9 @@ mod tests {
     use super::*;
     use approx::assert_abs_diff_eq;
     use core::f64::consts::PI;
+
+    #[cfg(not(feature = "std"))]
+    use alloc::format;
 
     #[test]
     fn golub_welsch_2_alpha_5() {

--- a/src/legendre/bogaert/mod.rs
+++ b/src/legendre/bogaert/mod.rs
@@ -11,6 +11,7 @@
 #[rustfmt::skip]
 mod data;
 
+use crate::elementary::{cos, sin};
 use core::{cmp::Ordering, f64::consts::PI};
 use data::{CL, EVEN_THETA_ZEROS, EVEN_WEIGHTS, J1, JZ, ODD_THETA_ZEROS, ODD_WEIGHTS};
 
@@ -81,7 +82,7 @@ impl From<ThetaWeightPair> for NodeWeightPair {
     #[inline]
     fn from(value: ThetaWeightPair) -> Self {
         Self {
-            node: value.theta.cos(),
+            node: cos(value.theta),
             weight: value.weight,
         }
     }
@@ -142,7 +143,7 @@ impl ThetaWeightPair {
         let wsf3t = (((((((2.018_267_912_567_033e-9 * x - 4.386_471_225_202_067e-8) * x + 5.088_983_472_886_716e-7) * x - 3.979_333_165_191_352_5e-6) * x + 2.005_593_263_964_583_4e-5) * x - 4.228_880_592_829_212e-5) * x - 1.056_460_502_540_761_4e-4) * x - 9.479_693_089_585_773e-5) * x + 6.569_664_899_264_848e-3;
 
         // Then refine with the expansions from the paper
-        let nu_o_sin = nu / theta.sin();
+        let nu_o_sin = nu / sin(theta);
         let b_nu_o_sin = b * nu_o_sin;
         let w_inv_sinc = w * w * nu_o_sin;
         let wis2 = w_inv_sinc * w_inv_sinc;

--- a/src/legendre/mod.rs
+++ b/src/legendre/mod.rs
@@ -32,7 +32,11 @@ use bogaert::NodeWeightPair;
 
 use crate::{Node, Weight, __impl_node_weight_rule};
 
+#[cfg(feature = "std")]
 use std::backtrace::Backtrace;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
 /// A Gauss-Legendre quadrature scheme.
 ///
@@ -177,7 +181,10 @@ __impl_node_weight_rule! {GaussLegendre, GaussLegendreNodes, GaussLegendreWeight
 
 /// The error returned by [`GaussLegendre::new`] if it's given a degree of 0 or 1.
 #[derive(Debug)]
-pub struct GaussLegendreError(Backtrace);
+pub struct GaussLegendreError {
+    #[cfg(feature = "std")]
+    backtrace: Backtrace,
+}
 
 use core::fmt;
 impl fmt::Display for GaussLegendreError {
@@ -192,25 +199,31 @@ impl fmt::Display for GaussLegendreError {
 impl GaussLegendreError {
     /// Calls [`Backtrace::capture`] and wraps the result in a `GaussLegendreError` struct.
     fn new() -> Self {
-        Self(Backtrace::capture())
+        Self {
+            #[cfg(feature = "std")]
+            backtrace: Backtrace::capture(),
+        }
     }
 
+    #[cfg(feature = "std")]
     /// Returns a [`Backtrace`] to where the error was created.
     ///
     /// This backtrace is captured with [`Backtrace::capture`], see it for more information about how to make it display information when printed.
     #[inline]
     pub fn backtrace(&self) -> &Backtrace {
-        &self.0
+        &self.backtrace
     }
 }
 
-impl std::error::Error for GaussLegendreError {}
+impl core::error::Error for GaussLegendreError {}
 
 #[cfg(test)]
 mod tests {
     use approx::assert_abs_diff_eq;
 
     use super::*;
+
+    use alloc::format;
 
     #[test]
     fn check_degree_3() {

--- a/src/legendre/mod.rs
+++ b/src/legendre/mod.rs
@@ -223,6 +223,7 @@ mod tests {
 
     use super::*;
 
+    #[cfg(not(feature = "std"))]
     use alloc::format;
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,9 @@
 //!
 //! ## Feature flags
 //!
+//! `std`: enables the error types like e.g. [`GaussLegendreError`](legendre::GaussLegendreError), to capture a [`Backtrace`](std::backtrace::Backtrace).
+//! If this feature is disabled the crate is `no_std` compatible.
+//!
 //! `serde`: implements the [`Serialize`](serde::Serialize) and [`Deserialize`](serde::Deserialize) traits from
 //! the [`serde`](https://crates.io/crates/serde) crate for the quatrature rule structs.
 //!
@@ -172,6 +175,10 @@
 // or if the environment variable RUSTDOCFLAGS is set as `RUSTDOCFLAGS="--cfg docsrs"`.
 // This lets us get a tag on docs.rs that says "Available on crate feature ... only".
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
 
 use nalgebra::{Dyn, Matrix, VecStorage};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,7 @@
 //! the [`serde`](https://crates.io/crates/serde) crate for the quatrature rule structs.
 //!
 //! `rayon`: enables a parallel version of the `integrate` function on the quadrature rule structs. Can speed up integration if evaluating the integrand is expensive.
+//! Note that [`rayon`] depends on the standard library.
 
 // Only enable the nighlty `doc_auto_cfg` feature when
 // the `docsrs` configuration attribute is defined.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,6 +186,7 @@ use nalgebra::{Dyn, Matrix, VecStorage};
 type DMatrixf64 = Matrix<f64, Dyn, Dyn, VecStorage<f64, Dyn, Dyn>>;
 
 mod data_api;
+mod elementary;
 mod gamma;
 pub mod hermite;
 pub mod jacobi;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@
 //!
 //! ## Feature flags
 //!
-//! `std`: enables the error types like e.g. [`GaussLegendreError`](legendre::GaussLegendreError), to capture a [`Backtrace`](std::backtrace::Backtrace).
+//! `std`: enables the error types like e.g. [`GaussLegendreError`](legendre::GaussLegendreError) to capture a [`Backtrace`](std::backtrace::Backtrace).
 //! If this feature is disabled the crate is `no_std` compatible.
 //!
 //! `serde`: implements the [`Serialize`](serde::Serialize) and [`Deserialize`](serde::Deserialize) traits from

--- a/src/simpson/mod.rs
+++ b/src/simpson/mod.rs
@@ -176,7 +176,7 @@ impl SimpsonError {
     /// This backtrace is captured with [`Backtrace::capture`], see it for more information about how to make it display information when printed.
     #[inline]
     pub fn backtrace(&self) -> &Backtrace {
-        &self.0
+        &self.backtrace
     }
 }
 


### PR DESCRIPTION
I may have figured out a way to make the crate `no_std` compatible!

I added the `std` feature (disabled by default currently) that can be activated to enable the current `Backtrace` functionality of the error types, since that needs the standard library.

## Potential trade-offs:  
- `rayon` depends on the standard library, so if that feature is enabled it doesn't really matter that we are `no_std`.
- Depend on the `libm` crate to compute square roots and trigonometric functions if the `std` feature is disabled. When the `std` feature is enabled we depend on `libm` even if we never use it.
- Increases the minimum compatible Rust version to 1.81 since we then use the `Error` trait in core.

## Roadblocks
Currently the compiler complains when I run `cargo check` that there is no allocator, but it works when I run `cargo test`. I do not know how to resolve this yet. I am also confused about why it doesn't work right now, as I have already used the functionality I use here to make my `const-primes` crate `no_std`, and that worked without this issue.