### PR TITLE
Correct links in `data_api` module docs

### DIFF
--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -1,7 +1,7 @@
 //! The macros in this module define the common API for accessing the data that underlies the quadrature rules.
 //! The [`__impl_node_weight_rule!`] macro implements the API for a struct with both nodes and weights.
 //! It should be called in the module that defines the quadrature rule struct.
-//! [`__impl_node_rule!`] does the same thing as the previous macros
+//! [`__impl_node_rule!`] does the same thing as the previous macro
 //! but for a struct with only nodes and no weights.
 
 // The code in the macros uses fully qualified paths for every type, so it is quite verbose.

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -1,9 +1,7 @@
 //! The macros in this module define the common API for accessing the data that underlies the quadrature rules.
 //! The [`__impl_node_weight_rule!`] macro implements the API for a struct with both nodes and weights.
 //! It should be called in the module that defines the quadrature rule struct.
-//! The [`__impl_node_weight_rule_iterators!`] macro defines the iterators that some of the functions return.
-//! It should be called somewhere it makes sense for the iterators to be defined, e.g. a sub-module.
-//! The [`__impl_node_rule!`] and [`__impl_node_rule_iterators!`] do the same thing as the previous
+//! [`__impl_node_rule!`] do the same thing as the previous
 //! macros but for a struct with only nodes and no weights.
 
 // The code in the macros uses fully qualified paths for every type, so it is quite verbose.

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -1,9 +1,9 @@
 //! The macros in this module define the common API for accessing the data that underlies the quadrature rules.
-//! The [`impl_node_weight_rule!`] macro implements the API for a struct with both nodes and weights.
+//! The [`__impl_node_weight_rule!`] macro implements the API for a struct with both nodes and weights.
 //! It should be called in the module that defines the quadrature rule struct.
-//! The [`impl_node_weight_rule_iterators!`] macro defines the iterators that some of the functions return.
+//! The [`__impl_node_weight_rule_iterators!`] macro defines the iterators that some of the functions return.
 //! It should be called somewhere it makes sense for the iterators to be defined, e.g. a sub-module.
-//! The [`impl_node_rule!`] and [`impl_node_rule_iterators!`] do the same thing as the previous
+//! The [`__impl_node_rule!`] and [`__impl_node_rule_iterators!`] do the same thing as the previous
 //! macros but for a struct with only nodes and no weights.
 
 // The code in the macros uses fully qualified paths for every type, so it is quite verbose.

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -1,8 +1,8 @@
 //! The macros in this module define the common API for accessing the data that underlies the quadrature rules.
 //! The [`__impl_node_weight_rule!`] macro implements the API for a struct with both nodes and weights.
 //! It should be called in the module that defines the quadrature rule struct.
-//! [`__impl_node_rule!`] do the same thing as the previous
-//! macros but for a struct with only nodes and no weights.
+//! [`__impl_node_rule!`] does the same thing as the previous macros
+//! but for a struct with only nodes and no weights.
 
 // The code in the macros uses fully qualified paths for every type, so it is quite verbose.
 // That is, instead of `usize` it uses `::core::primitive::usize` and so on. This makes it so that


### PR DESCRIPTION
Those docs included links to macros that were removed, and used the wrong names for macros that still exist.