### PR TITLE
Let the sums over edges and midpoints in `Simpson::par_integrate` potentially run in parallel

### DIFF
--- a/src/simpson/mod.rs
+++ b/src/simpson/mod.rs
@@ -118,17 +118,22 @@ impl Simpson {
 
         let h = (b - a) / n;
 
-        let (sum_over_interval_edges, sum_over_midpoints) = self
-            .nodes
-            .par_iter()
-            .skip(1)
-            .map(|&node| {
-                (
-                    integrand(a + node * h),
-                    integrand(a + (2.0 * node - 1.0) * h / 2.0),
-                )
-            })
-            .sum();
+        let (sum_over_interval_edges, sum_over_midpoints): (f64, f64) = rayon::join(
+            || {
+                self.nodes
+                    .par_iter()
+                    .skip(1)
+                    .map(|&node| integrand(a + node * h))
+                    .sum::<f64>()
+            },
+            || {
+                self.nodes
+                    .par_iter()
+                    .skip(1)
+                    .map(|&node| integrand(a + (2.0 * node - 1.0) * h / 2.0))
+                    .sum::<f64>()
+            },
+        );
 
         h / 6.0
             * (2.0 * sum_over_interval_edges

--- a/src/simpson/mod.rs
+++ b/src/simpson/mod.rs
@@ -118,18 +118,16 @@ impl Simpson {
 
         let h = (b - a) / n;
 
-        let sum_over_interval_edges: f64 = self
+        let (sum_over_interval_edges, sum_over_midpoints) = self
             .nodes
             .par_iter()
             .skip(1)
-            .map(|&node| integrand(a + node * h))
-            .sum();
-
-        let sum_over_midpoints: f64 = self
-            .nodes
-            .par_iter()
-            .skip(1)
-            .map(|&node| integrand(a + (2.0 * node - 1.0) * h / 2.0))
+            .map(|&node| {
+                (
+                    integrand(a + node * h),
+                    integrand(a + (2.0 * node - 1.0) * h / 2.0),
+                )
+            })
             .sum();
 
         h / 6.0


### PR DESCRIPTION
This PR makes the sums over the edges and midpoints in the `Simpson::par_integrate` function able to run in parallel with each other by using [`rayon::join`](https://docs.rs/rayon/latest/rayon/fn.join.html). This speeds up the benchmarks by up to 37% on my machine:

![bild](https://github.com/user-attachments/assets/ec1c08e2-0ef4-48cf-bdea-c566f83e8561)

The effect is largest on the benchmarks with small degrees where a single sum is not enough to saturate multiple cores, larger degrees only see a small improvement:

![bild](https://github.com/user-attachments/assets/a2ea265f-71a4-4ada-96d8-66e2c26729ef)
