### PR TITLE
Add wikipedia links to the docs of each struct.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The `gauss-quad` crate is a small library to calculate integrals of the type
 
 $$\int_a^b f(x) w(x) \mathrm{d}x$$
 
-using Gaussian quadrature. 
+using [Gaussian quadrature](https://en.wikipedia.org/wiki/Gaussian_quadrature).
 
 Here $f(x)$ is a user supplied function
 and $w(x)$ is a weight function that depends on which rule is used.

--- a/src/hermite/mod.rs
+++ b/src/hermite/mod.rs
@@ -29,7 +29,7 @@ use core::f64::consts::PI;
 
 use std::backtrace::Backtrace;
 
-/// A Gauss-Hermite quadrature scheme.
+/// A [Gauss-Hermite quadrature](https://en.wikipedia.org/wiki/Gauss%E2%80%93Hermite_quadrature) scheme.
 ///
 /// These rules can integrate integrands of the form e^(-x^2) * f(x) over the domain (-∞, ∞).
 ///

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -27,7 +27,7 @@ use crate::{DMatrixf64, Node, Weight, __impl_node_weight_rule};
 
 use std::backtrace::Backtrace;
 
-/// A Gauss-Jacobi quadrature scheme.
+/// A [Gauss-Jacobi quadrature](https://en.wikipedia.org/wiki/Gauss%E2%80%93Jacobi_quadrature) scheme.
 ///
 /// This rule can integrate expressions of the form (1 - x)^alpha * (1 + x)^beta * f(x),
 /// where f(x) is a smooth function on a finite domain, alpha > -1 and beta > -1,

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -26,7 +26,7 @@ use crate::{DMatrixf64, Node, Weight, __impl_node_weight_rule};
 
 use std::backtrace::Backtrace;
 
-/// A Gauss-Laguerre quadrature scheme.
+/// A [Gauss-Laguerre quadrature](https://en.wikipedia.org/wiki/Gauss%E2%80%93Laguerre_quadrature) scheme.
 ///
 /// These rules can perform integrals with integrands of the form x^alpha * e^(-x) * f(x) over the domain [0, ∞).
 ///

--- a/src/legendre/mod.rs
+++ b/src/legendre/mod.rs
@@ -34,7 +34,7 @@ use crate::{Node, Weight, __impl_node_weight_rule};
 
 use std::backtrace::Backtrace;
 
-/// A Gauss-Legendre quadrature scheme.
+/// A [Gauss-Legendre quadrature](https://en.wikipedia.org/wiki/Gauss%E2%80%93Legendre_quadrature) scheme.
 ///
 /// These rules can integrate functions on the domain [a, b].
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! # gauss-quad
 //!
-//! **gauss-quad** is a Gaussian quadrature library for numerical integration.
+//! **gauss-quad** is a [Gaussian quadrature](https://en.wikipedia.org/wiki/Gaussian_quadrature) library for numerical integration.
 //!
 //! ## Quadrature rules
 //!

--- a/src/midpoint/mod.rs
+++ b/src/midpoint/mod.rs
@@ -48,7 +48,7 @@ use crate::{Node, __impl_node_rule};
 
 use std::backtrace::Backtrace;
 
-/// A midpoint rule quadrature scheme.
+/// A [midpoint rule quadrature](https://en.wikipedia.org/wiki/Riemann_sum#Midpoint_rule) scheme.
 /// ```
 /// # use gauss_quad::midpoint::{Midpoint, MidpointError};
 /// // initialize a midpoint rule with 100 cells

--- a/src/simpson/mod.rs
+++ b/src/simpson/mod.rs
@@ -41,7 +41,7 @@ use crate::{Node, __impl_node_rule};
 
 use std::backtrace::Backtrace;
 
-/// A Simpson rule quadrature scheme.
+/// A [Simpson rule quadrature](https://en.wikipedia.org/wiki/Simpson%27s_rule) scheme.
 /// ```
 /// # use gauss_quad::simpson::{Simpson, SimpsonError};
 /// // initialize a Simpson rule with 100 subintervals


### PR DESCRIPTION
This PR adds links to the corresponding wikipedia page for each quadrature rule.