### PR TITLE
Move wiki links to the beginning of the crate docs instead of the structs

### DIFF
--- a/src/hermite/mod.rs
+++ b/src/hermite/mod.rs
@@ -1,4 +1,4 @@
-//! Numerical integration using the Gauss-Hermite quadrature rule.
+//! Numerical integration using the [Gauss-Hermite quadrature](https://en.wikipedia.org/wiki/Gauss%E2%80%93Hermite_quadrature) rule.
 //!
 //! This rule can integrate integrands of the form  
 //! e^(-x^2) * f(x)  
@@ -29,7 +29,7 @@ use core::f64::consts::PI;
 
 use std::backtrace::Backtrace;
 
-/// A [Gauss-Hermite quadrature](https://en.wikipedia.org/wiki/Gauss%E2%80%93Hermite_quadrature) scheme.
+/// A Gauss-Hermite quadrature scheme.
 ///
 /// These rules can integrate integrands of the form e^(-x^2) * f(x) over the domain (-∞, ∞).
 ///

--- a/src/hermite/mod.rs
+++ b/src/hermite/mod.rs
@@ -1,4 +1,4 @@
-//! Numerical integration using the [Gauss-Hermite quadrature](https://en.wikipedia.org/wiki/Gauss%E2%80%93Hermite_quadrature) rule.
+//! Numerical integration using the Gauss-Hermite quadrature rule.
 //!
 //! This rule can integrate integrands of the form  
 //! e^(-x^2) * f(x)  

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -1,4 +1,4 @@
-//! Numerical integration using the [Gauss-Jacobi quadrature](https://en.wikipedia.org/wiki/Gauss%E2%80%93Jacobi_quadrature) rule.
+//! Numerical integration using the Gauss-Jacobi quadrature rule.
 //!
 //! This rule can integrate expressions of the form (1 - x)^alpha * (1 + x)^beta * f(x),
 //! where f(x) is a smooth function on a finite domain, alpha > -1 and beta > -1, and where f(x) is transformed from the domain [a, b] to the domain [-1, 1].

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -1,4 +1,4 @@
-//! Numerical integration using the Gauss-Jacobi quadrature rule.
+//! Numerical integration using the [Gauss-Jacobi quadrature](https://en.wikipedia.org/wiki/Gauss%E2%80%93Jacobi_quadrature) rule.
 //!
 //! This rule can integrate expressions of the form (1 - x)^alpha * (1 + x)^beta * f(x),
 //! where f(x) is a smooth function on a finite domain, alpha > -1 and beta > -1, and where f(x) is transformed from the domain [a, b] to the domain [-1, 1].
@@ -27,7 +27,7 @@ use crate::{DMatrixf64, Node, Weight, __impl_node_weight_rule};
 
 use std::backtrace::Backtrace;
 
-/// A [Gauss-Jacobi quadrature](https://en.wikipedia.org/wiki/Gauss%E2%80%93Jacobi_quadrature) scheme.
+/// A Gauss-Jacobi quadrature scheme.
 ///
 /// This rule can integrate expressions of the form (1 - x)^alpha * (1 + x)^beta * f(x),
 /// where f(x) is a smooth function on a finite domain, alpha > -1 and beta > -1,

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -1,4 +1,4 @@
-//! Numerical integration using the generalized [Gauss-Laguerre quadrature](https://en.wikipedia.org/wiki/Gauss%E2%80%93Laguerre_quadrature#Generalized_Gauss%E2%80%93Laguerre_quadrature) rule.
+//! Numerical integration using the [generalized Gauss-Laguerre quadrature](https://en.wikipedia.org/wiki/Gauss%E2%80%93Laguerre_quadrature#Generalized_Gauss%E2%80%93Laguerre_quadrature) rule.
 //!
 //! A Gauss-Laguerre rule of degree `n` has nodes and weights chosen such that it
 //! can integrate polynomials of degree 2`n`-1 exactly

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -1,4 +1,4 @@
-//! Numerical integration using the generalized Gauss-Laguerre quadrature rule.
+//! Numerical integration using the generalized [Gauss-Laguerre quadrature](https://en.wikipedia.org/wiki/Gauss%E2%80%93Laguerre_quadrature) rule.
 //!
 //! A Gauss-Laguerre rule of degree `n` has nodes and weights chosen such that it
 //! can integrate polynomials of degree 2`n`-1 exactly
@@ -26,7 +26,7 @@ use crate::{DMatrixf64, Node, Weight, __impl_node_weight_rule};
 
 use std::backtrace::Backtrace;
 
-/// A [Gauss-Laguerre quadrature](https://en.wikipedia.org/wiki/Gauss%E2%80%93Laguerre_quadrature) scheme.
+/// A Gauss-Laguerre quadrature scheme.
 ///
 /// These rules can perform integrals with integrands of the form x^alpha * e^(-x) * f(x) over the domain [0, ∞).
 ///

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -1,4 +1,4 @@
-//! Numerical integration using the [generalized Gauss-Laguerre quadrature](https://en.wikipedia.org/wiki/Gauss%E2%80%93Laguerre_quadrature#Generalized_Gauss%E2%80%93Laguerre_quadrature) rule.
+//! Numerical integration using the generalized Gauss-Laguerre quadrature rule.
 //!
 //! A Gauss-Laguerre rule of degree `n` has nodes and weights chosen such that it
 //! can integrate polynomials of degree 2`n`-1 exactly

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -1,4 +1,4 @@
-//! Numerical integration using the generalized [Gauss-Laguerre quadrature](https://en.wikipedia.org/wiki/Gauss%E2%80%93Laguerre_quadrature) rule.
+//! Numerical integration using the generalized [Gauss-Laguerre quadrature](https://en.wikipedia.org/wiki/Gauss%E2%80%93Laguerre_quadrature#Generalized_Gauss%E2%80%93Laguerre_quadrature) rule.
 //!
 //! A Gauss-Laguerre rule of degree `n` has nodes and weights chosen such that it
 //! can integrate polynomials of degree 2`n`-1 exactly

--- a/src/legendre/mod.rs
+++ b/src/legendre/mod.rs
@@ -1,4 +1,4 @@
-//! Numerical integration using the [Gauss-Legendre quadrature](https://en.wikipedia.org/wiki/Gauss%E2%80%93Legendre_quadrature) rule.
+//! Numerical integration using the Gauss-Legendre quadrature rule.
 //!
 //! A Gauss-Legendre quadrature rule of degree n can integrate
 //! degree 2n-1 polynomials exactly.

--- a/src/legendre/mod.rs
+++ b/src/legendre/mod.rs
@@ -1,7 +1,7 @@
-//! Numerical integration using the Gauss-Legendre quadrature rule.
+//! Numerical integration using the [Gauss-Legendre quadrature]([Gauss-Legendre quadrature](https://en.wikipedia.org/wiki/Gauss%E2%80%93Legendre_quadrature)) rule.
 //!
-//! A Gauss-Legendre quadrature rule of degree `n` can integrate
-//! degree 2`n`-1 polynomials exactly.
+//! A Gauss-Legendre quadrature rule of degree n can integrate
+//! degree 2n-1 polynomials exactly.
 //!
 //! Evaluation point x_i of a degree n rule is the i:th root
 //! of Legendre polynomial P_n and its weight is  
@@ -34,7 +34,7 @@ use crate::{Node, Weight, __impl_node_weight_rule};
 
 use std::backtrace::Backtrace;
 
-/// A [Gauss-Legendre quadrature](https://en.wikipedia.org/wiki/Gauss%E2%80%93Legendre_quadrature) scheme.
+/// A Gauss-Legendre quadrature scheme.
 ///
 /// These rules can integrate functions on the domain [a, b].
 ///

--- a/src/legendre/mod.rs
+++ b/src/legendre/mod.rs
@@ -1,4 +1,4 @@
-//! Numerical integration using the [Gauss-Legendre quadrature]([Gauss-Legendre quadrature](https://en.wikipedia.org/wiki/Gauss%E2%80%93Legendre_quadrature)) rule.
+//! Numerical integration using the [Gauss-Legendre quadrature](https://en.wikipedia.org/wiki/Gauss%E2%80%93Legendre_quadrature) rule.
 //!
 //! A Gauss-Legendre quadrature rule of degree n can integrate
 //! degree 2n-1 polynomials exactly.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,12 +5,12 @@
 //! ## Quadrature rules
 //!
 //! **gauss-quad** implements the following quadrature rules:
-//! * Gauss-Legendre
-//! * Gauss-Jacobi
-//! * Gauss-Laguerre
-//! * Gauss-Hermite
-//! * Midpoint
-//! * Simpson
+//! * [Gauss-Legendre](https://en.wikipedia.org/wiki/Gauss%E2%80%93Legendre_quadrature)
+//! * [Gauss-Jacobi](https://en.wikipedia.org/wiki/Gauss%E2%80%93Jacobi_quadrature)
+//! * [Gauss-Laguerre](https://en.wikipedia.org/wiki/Gauss%E2%80%93Laguerre_quadrature) (generalized)
+//! * [Gauss-Hermite](https://en.wikipedia.org/wiki/Gauss%E2%80%93Hermite_quadrature)
+//! * [Midpoint](https://en.wikipedia.org/wiki/Riemann_sum#Midpoint_rule)
+//! * [Simpson](https://en.wikipedia.org/wiki/Simpson%27s_rule)
 //!
 //! ## Using **gauss-quad**
 //!

--- a/src/midpoint/mod.rs
+++ b/src/midpoint/mod.rs
@@ -1,4 +1,4 @@
-//! Numerical integration using the [midpoint rule](https://en.wikipedia.org/wiki/Riemann_sum#Midpoint_rule).
+//! Numerical integration using the midpoint rule.
 //!
 //! This is one of the simplest integration schemes.
 //!

--- a/src/midpoint/mod.rs
+++ b/src/midpoint/mod.rs
@@ -1,4 +1,4 @@
-//! Numerical integration using the midpoint rule.
+//! Numerical integration using the [midpoint rule](https://en.wikipedia.org/wiki/Riemann_sum#Midpoint_rule).
 //!
 //! This is one of the simplest integration schemes.
 //!
@@ -48,7 +48,7 @@ use crate::{Node, __impl_node_rule};
 
 use std::backtrace::Backtrace;
 
-/// A [midpoint rule quadrature](https://en.wikipedia.org/wiki/Riemann_sum#Midpoint_rule) scheme.
+/// A midpoint rule.
 /// ```
 /// # use gauss_quad::midpoint::{Midpoint, MidpointError};
 /// // initialize a midpoint rule with 100 cells

--- a/src/simpson/mod.rs
+++ b/src/simpson/mod.rs
@@ -1,4 +1,4 @@
-//! Numerical integration using the [Simpson rule](https://en.wikipedia.org/wiki/Simpson%27s_rule).
+//! Numerical integration using a [Simpson's rule](https://en.wikipedia.org/wiki/Simpson%27s_rule).
 //!
 //! A popular quadrature rule (also known as Kepler's barrel rule). It can be derived
 //! in the simplest case by replacing the integrand with a parabola that has the same

--- a/src/simpson/mod.rs
+++ b/src/simpson/mod.rs
@@ -1,4 +1,4 @@
-//! Numerical integration using the Simpson rule.
+//! Numerical integration using the [Simpson rule](https://en.wikipedia.org/wiki/Simpson%27s_rule).
 //!
 //! A popular quadrature rule (also known as Kepler's barrel rule). It can be derived
 //! in the simplest case by replacing the integrand with a parabola that has the same
@@ -41,7 +41,7 @@ use crate::{Node, __impl_node_rule};
 
 use std::backtrace::Backtrace;
 
-/// A [Simpson rule quadrature](https://en.wikipedia.org/wiki/Simpson%27s_rule) scheme.
+/// A Simpson's rule.
 /// ```
 /// # use gauss_quad::simpson::{Simpson, SimpsonError};
 /// // initialize a Simpson rule with 100 subintervals

--- a/src/simpson/mod.rs
+++ b/src/simpson/mod.rs
@@ -1,4 +1,4 @@
-//! Numerical integration using a [Simpson's rule](https://en.wikipedia.org/wiki/Simpson%27s_rule).
+//! Numerical integration using a Simpson's rule.
 //!
 //! A popular quadrature rule (also known as Kepler's barrel rule). It can be derived
 //! in the simplest case by replacing the integrand with a parabola that has the same

--- a/src/simpson/mod.rs
+++ b/src/simpson/mod.rs
@@ -42,7 +42,7 @@ use crate::{Node, __impl_node_rule};
 use std::backtrace::Backtrace;
 
 /// A Simpson's rule.
-/// 
+///
 /// ```
 /// # use gauss_quad::simpson::{Simpson, SimpsonError};
 /// // initialize a Simpson rule with 100 subintervals

--- a/src/simpson/mod.rs
+++ b/src/simpson/mod.rs
@@ -42,6 +42,7 @@ use crate::{Node, __impl_node_rule};
 use std::backtrace::Backtrace;
 
 /// A Simpson's rule.
+/// 
 /// ```
 /// # use gauss_quad::simpson::{Simpson, SimpsonError};
 /// // initialize a Simpson rule with 100 subintervals


### PR DESCRIPTION
It turns out that it's much cleaner that way because the rule names are first seen in the docs in the table at the start.