### PR TITLE
Add the trapezoid rule

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 //! * [Gauss-Laguerre](https://en.wikipedia.org/wiki/Gauss%E2%80%93Laguerre_quadrature) (generalized)
 //! * [Gauss-Hermite](https://en.wikipedia.org/wiki/Gauss%E2%80%93Hermite_quadrature)
 //! * [Gauss-Chebyshev](https://en.wikipedia.org/wiki/Chebyshev%E2%80%93Gauss_quadrature)
+//! * [Trapezoid](https://en.wikipedia.org/wiki/Trapezoidal_rule)
 //! * [Midpoint](https://en.wikipedia.org/wiki/Riemann_sum#Midpoint_rule)
 //! * [Simpson](https://en.wikipedia.org/wiki/Simpson%27s_rule)
 //!
@@ -187,6 +188,7 @@ pub mod laguerre;
 pub mod legendre;
 pub mod midpoint;
 pub mod simpson;
+pub mod trapezoid;
 
 #[doc(inline)]
 pub use chebyshev::{GaussChebyshevFirstKind, GaussChebyshevSecondKind};
@@ -204,3 +206,5 @@ pub use legendre::GaussLegendre;
 pub use midpoint::Midpoint;
 #[doc(inline)]
 pub use simpson::Simpson;
+#[doc(inline)]
+pub use trapezoid::Trapezoid;

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -89,7 +89,7 @@ impl Trapezoid {
     }
 
     /// Change the degree of the rule.
-    pub const fn change_degree(&mut self, new_degree: NonZeroU32) {
+    pub fn change_degree(&mut self, new_degree: NonZeroU32) {
         self.degree = new_degree;
     }
 

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -240,7 +240,7 @@ mod test {
     }
 
     #[test]
-    fn test_nodes_iter() {
+    fn test_iter() {
         let rule = Trapezoid::new(1000).unwrap();
         assert_eq!(rule.iter().size_hint(), (1001, Some(1001)));
         assert_eq!(rule.iter().next(), Some(0.0));
@@ -249,5 +249,18 @@ mod test {
         assert_eq!(rule.iter().count(), 1001);
         assert_eq!(rule.iter().next_back(), Some(1000.0));
         assert_eq!(rule.iter().nth_back(999), Some(1.0));
+    }
+
+    #[test]
+    fn test_into_iter() {
+        let rule = Trapezoid::new(1000).unwrap();
+
+        for (node, ans) in (&rule).into_iter().zip(0..=1000) {
+            assert_eq!(node, ans as f64);
+        }
+
+        for (node, ans) in rule.into_iter().zip(0..=1000) {
+            assert_eq!(node, ans as f64);
+        }
     }
 }

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -88,6 +88,11 @@ impl Trapezoid {
         self.degree
     }
 
+    /// Change the degree of the rule.
+    pub fn change_degree(&mut self, new_degree: NonZeroU32) {
+        self.degree = new_degree;
+    }
+
     /// Returns an iterator over the nodes of the rule.
     pub fn iter(&self) -> TrapezoidIter {
         TrapezoidIter::new(self.degree)
@@ -195,6 +200,19 @@ mod test {
         let rule = Trapezoid::new(1000.try_into().unwrap());
         assert_abs_diff_eq!(
             rule.par_integrate(1.0, 2.0, |x| x * x),
+            7.0 / 3.0,
+            epsilon = 1e-6
+        );
+    }
+
+    #[test]
+    fn test_degree_change() {
+        let mut rule = Trapezoid::new(1.try_into().unwrap());
+        assert_eq!(rule.degree().get(), 1);
+        rule.change_degree(1000.try_into().unwrap());
+        assert_eq!(rule.degree().get(), 1000);
+        assert_abs_diff_eq!(
+            rule.integrate(1.0, 2.0, |x| x * x),
             7.0 / 3.0,
             epsilon = 1e-6
         );

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -159,6 +159,11 @@ impl DoubleEndedIterator for TrapezoidNodes {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.0.next_back()
     }
+
+    #[inline]
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth_back(n)
+    }
 }
 
 impl FusedIterator for TrapezoidNodes {}
@@ -250,5 +255,6 @@ mod test {
         assert_eq!(rule.nodes().last(), Some(1000.0));
         assert_eq!(rule.nodes().count(), 1001);
         assert_eq!(rule.nodes().next_back(), Some(1000.0));
+        assert_eq!(rule.nodes().nth_back(999), Some(1.0));
     }
 }

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -240,4 +240,13 @@ mod test {
             epsilon = 1e-6
         );
     }
+
+    #[test]
+    fn test_nodes_iter() {
+        let rule = Trapezoid::new(1000).unwrap();
+        let mut nodes: TrapezoidNodes = rule.nodes();
+        assert_eq!(nodes.size_hint(), (1001, Some(1001)));
+        assert_eq!(nodes.next(), Some(0.0));
+        assert_eq!(nodes.last(), Some(1000.0));
+    }
 }

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -112,7 +112,7 @@ impl IntoIterator for &Trapezoid {
 }
 
 /// An iterator over the nodes of the trapezoid rule.
-/// 
+///
 /// Created by the [`iter`](Trapezoid::iter) method on [`Trapezoid`].
 #[derive(Debug, Clone)]
 pub struct TrapezoidIter(core::iter::Map<core::ops::RangeInclusive<u32>, fn(u32) -> f64>);

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -111,6 +111,7 @@ impl IntoIterator for &Trapezoid {
     }
 }
 
+/// An iterator over the nodes of the trapezoid rule.
 #[derive(Debug, Clone)]
 pub struct TrapezoidIter(core::iter::Map<core::ops::RangeInclusive<u32>, fn(u32) -> f64>);
 

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -70,7 +70,7 @@ impl Trapezoid {
         let delta_x = (b - a) / f64::from(self.degree);
         let edge_points = (integrand(a) + integrand(b)) / 2.0;
         let sum: f64 = (1..self.degree)
-            .map(|x| integrand(a + f64::from(x as f64) * delta_x))
+            .map(|x| integrand(a + f64::from(x) * delta_x))
             .sum();
         (edge_points + sum) * delta_x
     }

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -116,6 +116,26 @@ impl Trapezoid {
     }
 }
 
+impl IntoIterator for Trapezoid {
+    type Item = Node;
+    type IntoIter = TrapezoidIter;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        TrapezoidIter::new(self.degree)
+    }
+}
+
+impl IntoIterator for &Trapezoid {
+    type Item = Node;
+    type IntoIter = TrapezoidIter;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        TrapezoidIter::new(self.degree)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct TrapezoidIter(core::iter::Map<core::ops::RangeInclusive<usize>, fn(usize) -> f64>);
 

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -1,0 +1,119 @@
+//! Numerical integration using the uniform [Trapezoidal rule](https://en.wikipedia.org/wiki/Trapezoidal_rule).
+//!
+//! This rule can integrate functions on finite intervals, [a, b].
+
+use std::backtrace::Backtrace;
+
+/// A trapezoid rule.
+///
+/// # Example
+///
+/// ```
+/// use gauss_quad::Trapezoid;
+/// # use gauss_quad::trapezoid::TrapezoidError;
+/// # use approx::assert_abs_diff_eq;
+///
+/// // initialize a trapezoid rule with 1000 grid points.
+/// let rule = Trapezoid::new(1000)?;
+///
+/// // // numerically integrate a function from -1.0 to 1.0 using the rule.
+/// let integral = rule.integrate(-1.0, 1.0, |x| x * x - 1.0);
+///
+/// assert_abs_diff_eq!(integral, -4.0 / 3.0, epsilon = 1e-5);
+///
+/// # Ok::<(), TrapezoidError>(())
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Trapezoid {
+    degree: usize,
+}
+
+impl Trapezoid {
+    /// Create a new instance of the Trapezoid rule with the given degree.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the degree is less than 2.
+    pub fn new(degree: usize) -> Result<Self, TrapezoidError> {
+        if degree < 2 {
+            return Err(TrapezoidError::new());
+        }
+
+        Ok(Self { degree })
+    }
+
+    /// Integrate a function using the trapezoidal rule.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use gauss_quad::Trapezoid;
+    /// # use gauss_quad::trapezoid::TrapezoidError;
+    /// # use approx::assert_abs_diff_eq;
+    ///
+    /// let rule = Trapezoid::new(1000)?;
+    ///
+    /// assert_abs_diff_eq!(rule.integrate(1.0, 2.0, |x| x * x), 7.0 / 3.0, epsilon = 1e-6);
+    /// # Ok::<(), TrapezoidError>(())
+    /// ```
+    pub fn integrate<F>(&self, a: f64, b: f64, integrand: F) -> f64
+    where
+        F: Fn(f64) -> f64,
+    {
+        let delta_x = (b - a) / self.degree as f64;
+        let edge_points = (integrand(a) + integrand(b)) / 2.0;
+        let sum: f64 = (1..self.degree)
+            .map(|x| integrand(a + x as f64 * delta_x))
+            .sum();
+        (edge_points + sum) * delta_x
+    }
+
+    /// Returns the degree of the rule.
+    pub const fn degree(&self) -> usize {
+        self.degree
+    }
+
+    /// Changes the degree of the rule to the given value if possible.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the given degree is less than 2.
+    pub fn change_degree(&mut self, new_degree: usize) -> Result<(), TrapezoidError> {
+        match Self::new(new_degree) {
+            Ok(rule) => {
+                *self = rule;
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
+/// The error returned when the given degree of hte [`Trapezoid`] rule is 0 or 1.
+#[derive(Debug)]
+pub struct TrapezoidError {
+    backtrace: Backtrace,
+}
+
+impl TrapezoidError {
+    pub(crate) fn new() -> Self {
+        Self {
+            backtrace: Backtrace::capture(),
+        }
+    }
+
+    pub fn backtrace(&self) -> &Backtrace {
+        &self.backtrace
+    }
+}
+
+impl std::fmt::Display for TrapezoidError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "the degree of the Trapezoid rule must be greater than 1."
+        )
+    }
+}
+
+impl std::error::Error for TrapezoidError {}

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -57,7 +57,6 @@ impl Trapezoid {
     /// let rule = Trapezoid::new(1000)?;
     ///
     /// assert_abs_diff_eq!(rule.integrate(1.0, 2.0, |x| x * x), 7.0 / 3.0, epsilon = 1e-6);
-    ///
     /// # Ok::<(), TrapezoidError>(())
     /// ```
     pub fn integrate<F>(&self, a: f64, b: f64, integrand: F) -> f64

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -4,6 +4,9 @@
 
 use std::backtrace::Backtrace;
 
+#[cfg(feature = "rayon")]
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+
 /// A trapezoid rule.
 ///
 /// # Example
@@ -70,7 +73,7 @@ impl Trapezoid {
 
     #[cfg(feature = "rayon")]
     /// Same as [integrate](Self::integrate) but runs in parallel.
-    fn par_integrate<F>(&self, a: f64, b: f64, integrand: F) -> f64
+    pub fn par_integrate<F>(&self, a: f64, b: f64, integrand: F) -> f64
     where
         F: Fn(f64) -> f64 + Sync,
     {
@@ -168,6 +171,17 @@ mod test {
             rule.integrate(1.0, 2.0, |x| x * x),
             7.0 / 3.0,
             epsilon = 1e-1
+        );
+    }
+
+    #[cfg(feature = "rayon")]
+    #[test]
+    fn test_par_integration() {
+        let rule = Trapezoid::new(1000).unwrap();
+        assert_abs_diff_eq!(
+            rule.par_integrate(1.0, 2.0, |x| x * x),
+            7.0 / 3.0,
+            epsilon = 1e-6
         );
     }
 }

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -206,6 +206,8 @@ impl DoubleEndedIterator for TrapezoidIter {
 
 impl FusedIterator for TrapezoidIter {}
 
+impl ExactSizeIterator for TrapezoidIter {}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -94,11 +94,6 @@ impl Trapezoid {
         self.degree
     }
 
-    /// Change the degree of the rule.
-    pub fn change_degree(&mut self, new_degree: u32) -> Result<(), TrapezoidError> {
-        Self::new(new_degree).map(|rule| *self = rule)
-    }
-
     /// Returns an iterator over the nodes of the rule.
     pub fn iter(&self) -> TrapezoidIter {
         TrapezoidIter::new(self.degree)
@@ -240,19 +235,6 @@ mod test {
         let rule = Trapezoid::new(1000).unwrap();
         assert_abs_diff_eq!(
             rule.par_integrate(1.0, 2.0, |x| x * x),
-            7.0 / 3.0,
-            epsilon = 1e-6
-        );
-    }
-
-    #[test]
-    fn test_degree_change() {
-        let mut rule = Trapezoid::new(1).unwrap();
-        assert_eq!(rule.degree().get(), 1);
-        rule.change_degree(1000).unwrap();
-        assert_eq!(rule.degree().get(), 1000);
-        assert_abs_diff_eq!(
-            rule.integrate(1.0, 2.0, |x| x * x),
             7.0 / 3.0,
             epsilon = 1e-6
         );

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -111,21 +111,21 @@ impl Trapezoid {
     }
 
     /// Returns an iterator over the nodes of the rule.
-    pub fn nodes(&self) -> TrapezoidNodes {
-        TrapezoidNodes::new(self.degree)
+    pub fn iter(&self) -> TrapezoidIter {
+        TrapezoidIter::new(self.degree)
     }
 }
 
 #[derive(Debug, Clone)]
-pub struct TrapezoidNodes(core::iter::Map<core::ops::RangeInclusive<usize>, fn(usize) -> f64>);
+pub struct TrapezoidIter(core::iter::Map<core::ops::RangeInclusive<usize>, fn(usize) -> f64>);
 
-impl TrapezoidNodes {
+impl TrapezoidIter {
     pub(crate) fn new(degree: usize) -> Self {
         Self((0..=degree).map(|x| x as f64))
     }
 }
 
-impl Iterator for TrapezoidNodes {
+impl Iterator for TrapezoidIter {
     type Item = Node;
 
     #[inline]
@@ -154,7 +154,7 @@ impl Iterator for TrapezoidNodes {
     }
 }
 
-impl DoubleEndedIterator for TrapezoidNodes {
+impl DoubleEndedIterator for TrapezoidIter {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
         self.0.next_back()
@@ -166,7 +166,7 @@ impl DoubleEndedIterator for TrapezoidNodes {
     }
 }
 
-impl FusedIterator for TrapezoidNodes {}
+impl FusedIterator for TrapezoidIter {}
 
 /// The error returned when the given degree of the [`Trapezoid`] rule is 0 or 1.
 #[derive(Debug)]
@@ -249,12 +249,12 @@ mod test {
     #[test]
     fn test_nodes_iter() {
         let rule = Trapezoid::new(1000).unwrap();
-        assert_eq!(rule.nodes().size_hint(), (1001, Some(1001)));
-        assert_eq!(rule.nodes().next(), Some(0.0));
-        assert_eq!(rule.nodes().nth(999), Some(999.0));
-        assert_eq!(rule.nodes().last(), Some(1000.0));
-        assert_eq!(rule.nodes().count(), 1001);
-        assert_eq!(rule.nodes().next_back(), Some(1000.0));
-        assert_eq!(rule.nodes().nth_back(999), Some(1.0));
+        assert_eq!(rule.iter().size_hint(), (1001, Some(1001)));
+        assert_eq!(rule.iter().next(), Some(0.0));
+        assert_eq!(rule.iter().nth(999), Some(999.0));
+        assert_eq!(rule.iter().last(), Some(1000.0));
+        assert_eq!(rule.iter().count(), 1001);
+        assert_eq!(rule.iter().next_back(), Some(1000.0));
+        assert_eq!(rule.iter().nth_back(999), Some(1.0));
     }
 }

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -71,9 +71,9 @@ impl Trapezoid {
     where
         F: Fn(f64) -> f64 + Sync,
     {
-        let delta_x = (b - a) / f64::from(self.degree);
+        let delta_x = (b - a) / f64::from(self.degree.get());
         let edge_points = (integrand(a) + integrand(b)) / 2.0;
-        let sum: f64 = (1..self.degree)
+        let sum: f64 = (1..self.degree.get())
             .into_par_iter()
             .map(|x| integrand(a + f64::from(x) * delta_x))
             .sum();

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -231,7 +231,7 @@ mod test {
     #[cfg(feature = "rayon")]
     #[test]
     fn test_par_integration() {
-        let rule = Trapezoid::new(1000.try_into().unwrap());
+        let rule = Trapezoid::new(1000).unwrap();
         assert_abs_diff_eq!(
             rule.par_integrate(1.0, 2.0, |x| x * x),
             7.0 / 3.0,

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -253,13 +253,15 @@ mod test {
 
     #[test]
     fn test_into_iter() {
-        let rule = Trapezoid::new(1000).unwrap();
+        const DEGREE: u32 = 1000;
 
-        for (node, ans) in (&rule).into_iter().zip(0..=1000) {
+        let rule = Trapezoid::new(DEGREE).unwrap();
+
+        for (node, ans) in (&rule).into_iter().zip(0..=DEGREE) {
             assert_eq!(node, ans as f64);
         }
 
-        for (node, ans) in rule.into_iter().zip(0..=1000) {
+        for (node, ans) in rule.into_iter().zip(0..=DEGREE) {
             assert_eq!(node, ans as f64);
         }
     }

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -29,6 +29,7 @@ use crate::Node;
 /// # Ok::<(), core::num::TryFromIntError>(())
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Trapezoid {
     degree: NonZeroU32,
 }
@@ -57,9 +58,10 @@ impl Trapezoid {
     where
         F: Fn(f64) -> f64,
     {
-        let delta_x = (b - a) / f64::from(self.degree.get());
+        let degree = self.degree.get();
+        let delta_x = (b - a) / f64::from(degree);
         let edge_points = (integrand(a) + integrand(b)) / 2.0;
-        let sum: f64 = (1..self.degree.get())
+        let sum: f64 = (1..degree)
             .map(|x| integrand(a + f64::from(x) * delta_x))
             .sum();
         (edge_points + sum) * delta_x
@@ -71,9 +73,10 @@ impl Trapezoid {
     where
         F: Fn(f64) -> f64 + Sync,
     {
-        let delta_x = (b - a) / f64::from(self.degree.get());
+        let degree = self.degree.get();
+        let delta_x = (b - a) / f64::from(degree);
         let edge_points = (integrand(a) + integrand(b)) / 2.0;
-        let sum: f64 = (1..self.degree.get())
+        let sum: f64 = (1..degree)
             .into_par_iter()
             .map(|x| integrand(a + f64::from(x) * delta_x))
             .sum();

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -1,4 +1,4 @@
-//! Numerical integration using the uniform [Trapezoidal rule](https://en.wikipedia.org/wiki/Trapezoidal_rule).
+//! Numerical integration using the uniform Trapezoidal rule.
 //!
 //! This rule can integrate functions on finite intervals, [a, b].
 

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -244,9 +244,11 @@ mod test {
     #[test]
     fn test_nodes_iter() {
         let rule = Trapezoid::new(1000).unwrap();
-        let mut nodes: TrapezoidNodes = rule.nodes();
-        assert_eq!(nodes.size_hint(), (1001, Some(1001)));
-        assert_eq!(nodes.next(), Some(0.0));
-        assert_eq!(nodes.last(), Some(1000.0));
+        assert_eq!(rule.nodes().size_hint(), (1001, Some(1001)));
+        assert_eq!(rule.nodes().next(), Some(0.0));
+        assert_eq!(rule.nodes().nth(999), Some(999.0));
+        assert_eq!(rule.nodes().last(), Some(1000.0));
+        assert_eq!(rule.nodes().count(), 1001);
+        assert_eq!(rule.nodes().next_back(), Some(1000.0));
     }
 }

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -232,4 +232,10 @@ mod test {
         let rule = Trapezoid::new(1.try_into().unwrap());
         assert_eq!(rule.integrate(0.0, 1.0, |x| x), 0.5);
     }
+
+    #[test]
+    fn test_two_nodes() {
+        let rule = Trapezoid::new(2.try_into().unwrap());
+        assert_eq!(rule.integrate(0.0, 1.0, |x| x), 0.5);
+    }
 }

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -89,7 +89,7 @@ impl Trapezoid {
     }
 
     /// Change the degree of the rule.
-    pub fn change_degree(&mut self, new_degree: NonZeroU32) {
+    pub const fn change_degree(&mut self, new_degree: NonZeroU32) {
         self.degree = new_degree;
     }
 

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -95,21 +95,6 @@ impl Trapezoid {
         self.degree
     }
 
-    /// Changes the degree of the rule to the given value if possible.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the given degree is less than 2.
-    pub fn change_degree(&mut self, new_degree: u32) -> Result<(), TrapezoidError> {
-        match Self::new(new_degree) {
-            Ok(rule) => {
-                *self = rule;
-                Ok(())
-            }
-            Err(e) => Err(e),
-        }
-    }
-
     /// Returns an iterator over the nodes of the rule.
     pub fn iter(&self) -> TrapezoidIter {
         TrapezoidIter::new(self.degree)
@@ -238,20 +223,6 @@ mod test {
             rule.integrate(1.0, 2.0, |x| x * x),
             7.0 / 3.0,
             epsilon = 1e-6
-        );
-    }
-
-    #[test]
-    fn test_change_degree() {
-        let mut rule = Trapezoid::new(1000).unwrap();
-        assert!(rule.change_degree(0).is_err());
-        assert!(rule.change_degree(1).is_err());
-        assert!(rule.change_degree(2).is_ok());
-
-        assert_abs_diff_eq!(
-            rule.integrate(1.0, 2.0, |x| x * x),
-            7.0 / 3.0,
-            epsilon = 1e-1
         );
     }
 

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -112,6 +112,8 @@ impl IntoIterator for &Trapezoid {
 }
 
 /// An iterator over the nodes of the trapezoid rule.
+/// 
+/// Created by the [`iter`](Trapezoid::iter) method on [`Trapezoid`].
 #[derive(Debug, Clone)]
 pub struct TrapezoidIter(core::iter::Map<core::ops::RangeInclusive<u32>, fn(u32) -> f64>);
 

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -218,6 +218,12 @@ mod test {
     use approx::assert_abs_diff_eq;
 
     #[test]
+    fn check_error() {
+        assert!(Trapezoid::new(0).is_err());
+        assert!(Trapezoid::new(1).is_ok());
+    }
+
+    #[test]
     fn integrate_parabola() {
         let rule = Trapezoid::new(1000).unwrap();
         assert_eq!(rule.degree().get(), 1000);

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -181,8 +181,8 @@ impl Iterator for TrapezoidIter {
     }
 
     #[inline]
-    fn last(self) -> Option<Self::Item> {
-        self.0.last()
+    fn last(mut self) -> Option<Self::Item> {
+        self.0.next_back()
     }
 
     #[inline]

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -122,7 +122,7 @@ impl IntoIterator for Trapezoid {
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
-        TrapezoidIter::new(self.degree)
+        TrapezoidIter::new(self.degree())
     }
 }
 
@@ -132,7 +132,7 @@ impl IntoIterator for &Trapezoid {
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
-        TrapezoidIter::new(self.degree)
+        TrapezoidIter::new(self.degree())
     }
 }
 

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -195,10 +195,7 @@ impl TrapezoidError {
 
 impl std::fmt::Display for TrapezoidError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "the degree of the Trapezoid rule must be greater than 1."
-        )
+        write!(f, "the degree of the Trapezoid rule must be at least 2.")
     }
 }
 

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -188,6 +188,10 @@ impl TrapezoidError {
         }
     }
 
+    /// Returns a [`Backtrace`] to where the error was created.
+    ///
+    /// This backtrace is captured with [`Backtrace::capture`],
+    /// see it for more information about how to make it display information when printed.
     pub fn backtrace(&self) -> &Backtrace {
         &self.backtrace
     }

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -2,7 +2,9 @@
 //!
 //! This rule can integrate functions on finite intervals, [a, b].
 
-use std::{backtrace::Backtrace, iter::FusedIterator};
+use core::iter::FusedIterator;
+
+use std::backtrace::Backtrace;
 
 #[cfg(feature = "rayon")]
 use rayon::iter::{IntoParallelIterator, ParallelIterator};

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -16,7 +16,7 @@ use std::backtrace::Backtrace;
 /// // initialize a trapezoid rule with 1000 grid points.
 /// let rule = Trapezoid::new(1000)?;
 ///
-/// // // numerically integrate a function from -1.0 to 1.0 using the rule.
+/// // numerically integrate a function from -1.0 to 1.0 using the rule.
 /// let integral = rule.integrate(-1.0, 1.0, |x| x * x - 1.0);
 ///
 /// assert_abs_diff_eq!(integral, -4.0 / 3.0, epsilon = 1e-5);

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -9,6 +9,8 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 /// A trapezoid rule.
 ///
+/// This rule does not allocate anything on the heap.
+///
 /// # Example
 ///
 /// ```

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -36,36 +36,6 @@ pub struct Trapezoid {
     degree: NonZeroU32,
 }
 
-#[derive(Debug)]
-pub struct TrapezoidError {
-    backtrace: Backtrace,
-}
-
-impl fmt::Display for TrapezoidError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "degree must be greater than 0")
-    }
-}
-
-impl std::error::Error for TrapezoidError {}
-
-impl TrapezoidError {
-    /// Returns a [`Backtrace`] to where the error was created.
-    ///
-    /// This backtrace is captured with [`Backtrace::capture`], see it for more information about how to make it display information when printed.
-    #[inline]
-    pub fn backtrace(&self) -> &Backtrace {
-        &self.backtrace
-    }
-
-    #[inline]
-    pub(crate) fn new() -> Self {
-        Self {
-            backtrace: Backtrace::capture(),
-        }
-    }
-}
-
 impl Trapezoid {
     /// Create a new instance of the Trapezoid rule with the given degree.
     pub fn new(degree: u32) -> Result<Self, TrapezoidError> {
@@ -132,6 +102,36 @@ impl Trapezoid {
     /// Returns an iterator over the nodes of the rule.
     pub fn iter(&self) -> TrapezoidIter {
         TrapezoidIter::new(self.degree)
+    }
+}
+
+#[derive(Debug)]
+pub struct TrapezoidError {
+    backtrace: Backtrace,
+}
+
+impl fmt::Display for TrapezoidError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "degree must be greater than 0")
+    }
+}
+
+impl std::error::Error for TrapezoidError {}
+
+impl TrapezoidError {
+    /// Returns a [`Backtrace`] to where the error was created.
+    ///
+    /// This backtrace is captured with [`Backtrace::capture`], see it for more information about how to make it display information when printed.
+    #[inline]
+    pub fn backtrace(&self) -> &Backtrace {
+        &self.backtrace
+    }
+
+    #[inline]
+    pub(crate) fn new() -> Self {
+        Self {
+            backtrace: Backtrace::capture(),
+        }
     }
 }
 

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -66,7 +66,7 @@ impl Trapezoid {
     }
 
     #[cfg(feature = "rayon")]
-    /// Same as [integrate](Self::integrate) but runs in parallel.
+    /// Same as [`integrate`](Self::integrate) but runs in parallel.
     pub fn par_integrate<F>(&self, a: f64, b: f64, integrand: F) -> f64
     where
         F: Fn(f64) -> f64 + Sync,

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -219,4 +219,10 @@ mod test {
             assert_eq!(node, ans as f64);
         }
     }
+
+    #[test]
+    fn test_single_node() {
+        let rule = Trapezoid::new(1.try_into().unwrap());
+        assert_eq!(rule.integrate(0.0, 1.0, |x| x), 0.5);
+    }
 }

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -32,7 +32,7 @@ use crate::Node;
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Trapezoid {
-    degree: usize,
+    degree: u32,
 }
 
 impl Trapezoid {
@@ -41,7 +41,7 @@ impl Trapezoid {
     /// # Errors
     ///
     /// Returns an error if the degree is less than 2.
-    pub fn new(degree: usize) -> Result<Self, TrapezoidError> {
+    pub fn new(degree: u32) -> Result<Self, TrapezoidError> {
         if degree < 2 {
             return Err(TrapezoidError::new());
         }
@@ -67,10 +67,10 @@ impl Trapezoid {
     where
         F: Fn(f64) -> f64,
     {
-        let delta_x = (b - a) / self.degree as f64;
+        let delta_x = (b - a) / f64::from(self.degree);
         let edge_points = (integrand(a) + integrand(b)) / 2.0;
         let sum: f64 = (1..self.degree)
-            .map(|x| integrand(a + x as f64 * delta_x))
+            .map(|x| integrand(a + f64::from(x as f64) * delta_x))
             .sum();
         (edge_points + sum) * delta_x
     }
@@ -81,17 +81,17 @@ impl Trapezoid {
     where
         F: Fn(f64) -> f64 + Sync,
     {
-        let delta_x = (b - a) / self.degree as f64;
+        let delta_x = (b - a) / f64::from(self.degree);
         let edge_points = (integrand(a) + integrand(b)) / 2.0;
         let sum: f64 = (1..self.degree)
             .into_par_iter()
-            .map(|x| integrand(a + x as f64 * delta_x))
+            .map(|x| integrand(a + f64::from(x) * delta_x))
             .sum();
         (edge_points + sum) * delta_x
     }
 
     /// Returns the degree of the rule.
-    pub const fn degree(&self) -> usize {
+    pub const fn degree(&self) -> u32 {
         self.degree
     }
 
@@ -100,7 +100,7 @@ impl Trapezoid {
     /// # Errors
     ///
     /// Returns an error if the given degree is less than 2.
-    pub fn change_degree(&mut self, new_degree: usize) -> Result<(), TrapezoidError> {
+    pub fn change_degree(&mut self, new_degree: u32) -> Result<(), TrapezoidError> {
         match Self::new(new_degree) {
             Ok(rule) => {
                 *self = rule;
@@ -137,11 +137,11 @@ impl IntoIterator for &Trapezoid {
 }
 
 #[derive(Debug, Clone)]
-pub struct TrapezoidIter(core::iter::Map<core::ops::RangeInclusive<usize>, fn(usize) -> f64>);
+pub struct TrapezoidIter(core::iter::Map<core::ops::RangeInclusive<u32>, fn(u32) -> f64>);
 
 impl TrapezoidIter {
-    pub(crate) fn new(degree: usize) -> Self {
-        Self((0..=degree).map(|x| x as f64))
+    pub(crate) fn new(degree: u32) -> Self {
+        Self((0..=degree).map(f64::from))
     }
 }
 

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -118,6 +118,7 @@ impl IntoIterator for &Trapezoid {
 pub struct TrapezoidIter(core::iter::Map<core::ops::RangeInclusive<u32>, fn(u32) -> f64>);
 
 impl TrapezoidIter {
+    #[inline]
     pub(crate) fn new(degree: NonZeroU32) -> Self {
         Self((0..=degree.get()).map(f64::from))
     }

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -117,3 +117,41 @@ impl std::fmt::Display for TrapezoidError {
 }
 
 impl std::error::Error for TrapezoidError {}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use approx::assert_abs_diff_eq;
+
+    #[test]
+    fn test_error_in_new() {
+        assert!(Trapezoid::new(0).is_err());
+        assert!(Trapezoid::new(1).is_err());
+        assert!(Trapezoid::new(2).is_ok());
+    }
+
+    #[test]
+    fn integrate_parabola() {
+        let rule = Trapezoid::new(1000).unwrap();
+        assert_abs_diff_eq!(
+            rule.integrate(1.0, 2.0, |x| x * x),
+            7.0 / 3.0,
+            epsilon = 1e-6
+        );
+    }
+
+    #[test]
+    fn test_change_degree() {
+        let mut rule = Trapezoid::new(1000).unwrap();
+        assert!(rule.change_degree(0).is_err());
+        assert!(rule.change_degree(1).is_err());
+        assert!(rule.change_degree(2).is_ok());
+
+        assert_abs_diff_eq!(
+            rule.integrate(1.0, 2.0, |x| x * x),
+            7.0 / 3.0,
+            epsilon = 1e-1
+        );
+    }
+}

--- a/src/trapezoid/mod.rs
+++ b/src/trapezoid/mod.rs
@@ -35,7 +35,7 @@ pub struct Trapezoid {
 
 impl Trapezoid {
     /// Create a new instance of the Trapezoid rule with the given degree.
-    pub fn new(degree: NonZeroU32) -> Self {
+    pub const fn new(degree: NonZeroU32) -> Self {
         Self { degree }
     }
 


### PR DESCRIPTION
This PR adds an implementation of the Trapezoid rule. It does not allocate any memory to store the nodes, since those are trivial to compute.