### PR TITLE
Remove the wikipedia link in the module docs of the chebyshev module

### DIFF
--- a/src/chebyshev/mod.rs
+++ b/src/chebyshev/mod.rs
@@ -1,4 +1,4 @@
-//! Numerical integration using the [Gauss-Chebyshev quadrature](https://en.wikipedia.org/wiki/Chebyshev%E2%80%93Gauss_quadrature) rule.
+//! Numerical integration using the Gauss-Chebyshev quadrature rule.
 //!
 //! This rule can integrate formulas on the form f(x) * (1 - x^2)^`a` on finite intervals, where `a` is either -1/2 or 1/2.
 


### PR DESCRIPTION
This aligns it with the other modules.