### PR TITLE
allow stateful integrands with `fn integrate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Then to calculate the integral of a function call
 let integral = quad.integrate(a, b, f(x));
 ```
 
-where `a` and `b` (both `f64`) are the integral bounds and `f(x)` is the integrand which implements the trait `Fn(f64) -> f64`.
+where `a` and `b` (both `f64`) are the integral bounds and `f(x)` is the integrand which implements the trait `FnMut(f64) -> f64`.
 For example to integrate a parabola from 0 to 1 one can use a lambda expression as integrand and call:
 
 ```rust

--- a/src/chebyshev/mod.rs
+++ b/src/chebyshev/mod.rs
@@ -213,9 +213,9 @@ impl GaussChebyshevSecondKind {
     /// assert_relative_eq!(rule.integrate(-1.0, 1.0, |x| 1.5 * x * x - 0.5), -PI / 16.0);
     /// # Ok::<(), GaussChebyshevError>(())
     /// ```
-    pub fn integrate<F>(&self, a: f64, b: f64, integrand: F) -> f64
+    pub fn integrate<F>(&self, a: f64, b: f64, mut integrand: F) -> f64
     where
-        F: Fn(f64) -> f64,
+        F: FnMut(f64) -> f64,
     {
         let result: f64 = self
             .node_weight_pairs

--- a/src/chebyshev/mod.rs
+++ b/src/chebyshev/mod.rs
@@ -90,9 +90,9 @@ impl GaussChebyshevFirstKind {
     /// assert_relative_eq!(rule.integrate(-1.0, 1.0, |x| 1.5 * x * x - 0.5), PI / 4.0);
     /// # Ok::<(), GaussChebyshevError>(())
     /// ```
-    pub fn integrate<F>(&self, a: f64, b: f64, integrand: F) -> f64
+    pub fn integrate<F>(&self, a: f64, b: f64, mut integrand: F) -> f64
     where
-        F: Fn(f64) -> f64,
+        F: FnMut(f64) -> f64,
     {
         let result: f64 = self
             .node_weight_pairs

--- a/src/hermite/mod.rs
+++ b/src/hermite/mod.rs
@@ -108,9 +108,9 @@ impl GaussHermite {
     }
 
     /// Perform quadrature of e^(-x^2) * `integrand`(x) over the domain (-∞, ∞).
-    pub fn integrate<F>(&self, integrand: F) -> f64
+    pub fn integrate<F>(&self, mut integrand: F) -> f64
     where
-        F: Fn(f64) -> f64,
+        F: FnMut(f64) -> f64,
     {
         let result: f64 = self
             .node_weight_pairs

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -172,9 +172,9 @@ impl GaussJacobi {
     /// Perform quadrature of integrand from `a` to `b`. This will integrate  
     /// (1 - x)^`alpha` * (1 + x)^`beta` * `integrand`(x)  
     /// where `alpha` and `beta` were given in the call to [`new`](Self::new), and the integrand is transformed from the domain [a, b] to the domain [-1, 1].
-    pub fn integrate<F>(&self, a: f64, b: f64, integrand: F) -> f64
+    pub fn integrate<F>(&self, a: f64, b: f64, mut integrand: F) -> f64
     where
-        F: Fn(f64) -> f64,
+        F: FnMut(f64) -> f64,
     {
         let result: f64 = self
             .node_weight_pairs

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -123,9 +123,9 @@ impl GaussLaguerre {
     /// Perform quadrature of  
     /// x^`alpha` * e^(-x) * `integrand`(x)  
     /// over the domain `[0, ∞)`, where `alpha` was given in the call to [`new`](Self::new).
-    pub fn integrate<F>(&self, integrand: F) -> f64
+    pub fn integrate<F>(&self, mut integrand: F) -> f64
     where
-        F: Fn(f64) -> f64,
+        F: FnMut(f64) -> f64,
     {
         let result: f64 = self
             .node_weight_pairs

--- a/src/legendre/mod.rs
+++ b/src/legendre/mod.rs
@@ -135,9 +135,9 @@ impl GaussLegendre {
     ///
     /// # Ok::<(), GaussLegendreError>(())
     /// ```
-    pub fn integrate<F>(&self, a: f64, b: f64, integrand: F) -> f64
+    pub fn integrate<F>(&self, a: f64, b: f64, mut integrand: F) -> f64
     where
-        F: Fn(f64) -> f64,
+        F: FnMut(f64) -> f64,
     {
         let result: f64 = self
             .node_weight_pairs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@
 //!
 //! ## Passing functions to quadrature rules
 //!
-//! The `integrate` method takes any integrand that implements the [`Fn(f64) -> f64`](Fn) trait, i.e. functions of
+//! The `integrate` method takes any integrand that implements the [`FnMut(f64) -> f64`](Fn) trait, i.e. functions of
 //! one `f64` parameter.
 //!
 //! ```

--- a/src/midpoint/mod.rs
+++ b/src/midpoint/mod.rs
@@ -84,9 +84,9 @@ impl Midpoint {
     }
 
     /// Integrate over the domain [a, b].
-    pub fn integrate<F>(&self, a: f64, b: f64, integrand: F) -> f64
+    pub fn integrate<F>(&self, a: f64, b: f64, mut integrand: F) -> f64
     where
-        F: Fn(f64) -> f64,
+        F: FnMut(f64) -> f64,
     {
         let rect_width = (b - a) / self.nodes.len() as f64;
 

--- a/src/simpson/mod.rs
+++ b/src/simpson/mod.rs
@@ -76,9 +76,9 @@ impl Simpson {
     }
 
     /// Integrate over the domain [a, b].
-    pub fn integrate<F>(&self, a: f64, b: f64, integrand: F) -> f64
+    pub fn integrate<F>(&self, a: f64, b: f64, mut integrand: F) -> f64
     where
-        F: Fn(f64) -> f64,
+        F: FnMut(f64) -> f64,
     {
         let n = self.nodes.len() as f64;
 


### PR DESCRIPTION
Change the `integrand` argument from `Fn` to `FnMut`.

Some integrands need to collect temporary results in a `Vec<f64>`. Making a new allocation can be e.g. an order of magnitude slower than the actual computation, so it may be very beneficial to re-use this scratch space across calls to the integrand.

However, the type signature is currently `Fn` which precludes this optimization. (this can be hacked around with `Rc` but it is unnatural.)

Since `fn integrate` is actually single-threaded, there is no reason not to use `FnMut` here. `FnMut` is a less restrictive bound than `Fn`, so this is a non-breaking change.

See more on this topic: https://doc.rust-lang.org/std/ops/trait.Fn.html

```
Since both FnMut and FnOnce are supertraits of Fn, any instance of Fn can be used as a parameter where a FnMut or FnOnce is expected.

Use Fn as a bound when you want to accept a parameter of function-like type and need to call it repeatedly and without mutating state (e.g., when calling it concurrently). If you do not need such strict requirements, use FnMut or FnOnce as bounds.
```

The parallel version using rayon should continue to use `Fn` since in that case the integrand is actually being evaluated multiple times concurrently.