### PR TITLE
Implement `Iterator::last` by calling `DoubleEndedIterator::next_back` where applicable

### DIFF
--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -283,8 +283,8 @@ macro_rules! __impl_slice_iterator_newtype_traits {
             }
 
             #[inline]
-            fn last(self) -> ::core::option::Option<Self::Item> {
-                self.0.last()
+            fn last(mut self) -> ::core::option::Option<Self::Item> {
+                self.0.next_back()
             }
         }
 


### PR DESCRIPTION
This skips iterating through the entire iterator if `last` is called. It's an iterator over a slice, so it should not really result in any assembly improvements, but this fulfills the suggestion of a clippy lint added in rust 1.86.