### PR TITLE
Specify year and name in Apache license

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -186,7 +186,7 @@ APPENDIX: How to apply the Apache License to your work.
    same "printed page" as the copyright notice for easier
    identification within third-party archives.
 
-Copyright [yyyy] [name of copyright owner]
+Copyright 2019 Dominique Dresen
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -77,20 +77,3 @@ If the computation time for the evaluation of the integrand is large (≫100 µs
 ```rust
 let slow_integral = quad.par_integrate(a, b, |x| f(x));
 ```
-
-<br>
-
-### License
-
-<sup>
-Licensed under either of <a href="LICENSE-APACHE">Apache License, Version
-2.0</a> or <a href="LICENSE-MIT">MIT license</a> at your option.
-</sup>
-
-<br>
-
-<sub>
-Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
-dual licensed as above, without any additional terms or conditions.
-</sub>

--- a/README.md
+++ b/README.md
@@ -77,3 +77,20 @@ If the computation time for the evaluation of the integrand is large (≫100 µs
 ```rust
 let slow_integral = quad.par_integrate(a, b, |x| f(x));
 ```
+
+<br>
+
+### License
+
+<sup>
+Licensed under either of <a href="LICENSE-APACHE">Apache License, Version
+2.0</a> or <a href="LICENSE-MIT">MIT license</a> at your option.
+</sup>
+
+<br>
+
+<sub>
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.
+</sub>


### PR DESCRIPTION
It turns out that the copyright name and year were never added to the license! This PR fixes that.