### PR TITLE
Not what degree to select in the crate docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,8 @@
 //! # Ok::<(), GaussLegendreError>(())
 //! ```
 //!
+//! Select the degree, n, such that 2n-1 is the largest degree of polynomial that you want to integrate with the rule.
+//!
 //! ## Setting up a quadrature rule
 //!
 //! Using a quadrature rule takes two steps:


### PR DESCRIPTION
This just adds the information that it's a good idea to aim for a degree such that 2*deg - 1 is at least as large that largest degree polynomial one might want to integrate with the rule.