### PR TITLE
Add the `documentation` field to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 description = "Library for applying Gaussian quadrature to integrate a function"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/domidre/gauss-quad"
+documentation = "https://docs.rs/gauss-quad/"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This makes our crate appear with a "#Documentation" tag in the list of crates on crates.io.

I link to the normal documentation on docs.rs