### PR TITLE
Add a CI job that mimics the doc generation on docs.rs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,6 +57,17 @@ jobs:
       - name: Test all feature combinations
         run: cargo test-all-features
 
+  doc:
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
+      RUSTDOCFLAGS: --cfg docsrs
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@nightly
+    - name: Generate documentation
+      run: cargo +nightly doc --all-features
+
   semver_checks:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
It does this by running `cargo doc --all-features` on the nightly compiler with the `RUSTDOCFLAGS` env var set to `--cfg docsrs` and warnings set to deny.