### PR TITLE
Add a badge that takes you to the repo when clicked

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Crates.io Version](https://img.shields.io/crates/v/gauss-quad?logo=Rust)](https://crates.io/crates/gauss-quad)
 [![docs.rs](https://img.shields.io/docsrs/gauss-quad?logo=docs.rs)](https://docs.rs/gauss-quad/latest/gauss_quad/)
+[![Github Repository Link](https://img.shields.io/badge/github-DomiDre%2Fgauss--quad-8da0cb?logo=github)](https://github.com/DomiDre/gauss-quad)
 [![Build Status](https://github.com/domidre/gauss-quad/actions/workflows/rust.yml/badge.svg)](https://github.com/domidre/gauss-quad/actions/workflows/rust.yml)
 [![codecov](https://codecov.io/gh/DomiDre/gauss-quad/graph/badge.svg?token=YUP5Y77ER2)](https://codecov.io/gh/DomiDre/gauss-quad)
 


### PR DESCRIPTION
This way, regardless of whether you are reading about the crate on crates.io or github.com there is a link at the top to take you to the other one.