### PR TITLE
Make quadrature rules store a boxed slice instead of a Vec

### DIFF
--- a/src/chebyshev/mod.rs
+++ b/src/chebyshev/mod.rs
@@ -29,7 +29,7 @@ use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterato
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GaussChebyshevFirstKind {
-    node_weight_pairs: Vec<(Node, Weight)>,
+    node_weight_pairs: Box<[(Node, Weight)]>,
 }
 
 impl GaussChebyshevFirstKind {
@@ -138,7 +138,7 @@ __impl_node_weight_rule! {GaussChebyshevFirstKind, GaussChebyshevFirstKindNodes,
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GaussChebyshevSecondKind {
-    node_weight_pairs: Vec<(Node, Weight)>,
+    node_weight_pairs: Box<[(Node, Weight)]>,
 }
 
 impl GaussChebyshevSecondKind {

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -47,7 +47,7 @@ macro_rules! __impl_node_weight_rule {
             type Item = ($crate::Node, $crate::Weight);
             #[inline]
             fn into_iter(self) -> Self::IntoIter {
-                $quadrature_rule_into_iter::new(self.node_weight_pairs.into_iter())
+                $quadrature_rule_into_iter::new(self.node_weight_pairs.into_vec().into_iter())
             }
         }
 
@@ -96,7 +96,7 @@ macro_rules! __impl_node_weight_rule {
             /// This function just returns the underlying vector without any computation or cloning.
             #[inline]
             #[must_use = "`self` will be dropped if the result is not used"]
-            pub fn into_node_weight_pairs(self) -> ::std::vec::Vec<($crate::Node, $crate::Weight)> {
+            pub fn into_node_weight_pairs(self) -> ::std::boxed::Box<[($crate::Node, $crate::Weight)]> {
                 self.node_weight_pairs
             }
 
@@ -454,7 +454,7 @@ mod tests {
     #[derive(Debug, Clone, PartialEq)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     pub struct MockQuadrature {
-        node_weight_pairs: Vec<(Node, Weight)>,
+        node_weight_pairs: Box<[(Node, Weight)]>,
     }
 
     #[derive(Debug)]

--- a/src/hermite/mod.rs
+++ b/src/hermite/mod.rs
@@ -52,7 +52,7 @@ use std::backtrace::Backtrace;
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GaussHermite {
-    node_weight_pairs: Vec<(Node, Weight)>,
+    node_weight_pairs: Box<[(Node, Weight)]>,
 }
 
 impl GaussHermite {

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -53,7 +53,7 @@ use std::backtrace::Backtrace;
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GaussJacobi {
-    node_weight_pairs: Vec<(Node, Weight)>,
+    node_weight_pairs: Box<[(Node, Weight)]>,
     alpha: f64,
     beta: f64,
 }
@@ -131,8 +131,8 @@ impl GaussJacobi {
                 / gamma(alpha + beta + 1.0)
                 / (alpha + beta + 1.0);
 
-        // zip together the iterator over nodes with the one over weights and return as Vec<(f64, f64)>
-        let mut node_weight_pairs: Vec<(f64, f64)> = eigen
+        // zip together the iterator over nodes with the one over weights and return as Box<[(f64, f64)]>
+        let mut node_weight_pairs: Box<[(f64, f64)]> = eigen
             .eigenvalues
             .iter()
             .copied()

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -49,7 +49,7 @@ use std::backtrace::Backtrace;
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GaussLaguerre {
-    node_weight_pairs: Vec<(Node, Weight)>,
+    node_weight_pairs: Box<[(Node, Weight)]>,
     alpha: f64,
 }
 
@@ -101,8 +101,8 @@ impl GaussLaguerre {
 
         let scale_factor = gamma(alpha + 1.0);
 
-        // zip together the iterator over nodes with the one over weights and return as Vec<(f64, f64)>
-        let mut node_weight_pairs: Vec<(f64, f64)> = eigen
+        // zip together the iterator over nodes with the one over weights and return as Box<[(f64, f64)]>
+        let mut node_weight_pairs: Box<[(f64, f64)]> = eigen
             .eigenvalues
             .into_iter()
             .copied()

--- a/src/legendre/mod.rs
+++ b/src/legendre/mod.rs
@@ -68,7 +68,7 @@ use std::backtrace::Backtrace;
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GaussLegendre {
-    node_weight_pairs: Vec<(Node, Weight)>,
+    node_weight_pairs: Box<[(Node, Weight)]>,
 }
 
 impl GaussLegendre {


### PR DESCRIPTION
This does not affect the public API, but it reduces the stack size of all quadrature structs.