### PR TITLE
Store the node and weight data in a `SmallVec`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,8 @@ This document contains all changes to the crate since version 0.1.8.
  `QuadratureRule::weights()`, `QuadratureRule::as_node_weight_pairs()` and `QuadratureRule::into_node_weight_pairs()`.
 - Made the `Simpson` and `Midpoint` rules not allocate any memory. This removes all the functions on those types that access some view of the nodes.
 - Made the `new` functions that can only fail for a single reason return an `Option` instead of a `Result<Self, CustomError>`.
-- Made the quadrature rule structs that store a `Vec` of nodes and weights instead store a boxed slice. This makes them take up less space on the stack.
- This affects the `QuadratureRule::into_node_weight_pairs()` functions.
- Call `.into_vec()` on the boxed slice to get it as a `Vec`.
+- Made the quadrature rule structs that store a `Vec` of nodes and weights instead store a `SmallVec` from the `smallvec` crate. This enables them to store the nodes and weights inline on the stack if there aren't too many of them.
+ This affects the `QuadratureRule::into_node_weight_pairs()` functions, they can now allocate if the rule has a low enough degree.
 
 ### Other changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,7 @@ dependencies = [
  "nalgebra",
  "rayon",
  "serde",
+ "smallvec",
 ]
 
 [[package]]
@@ -534,6 +535,12 @@ dependencies = [
  "paste",
  "wide",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "syn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,6 +541,9 @@ name = "smallvec"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["lib", "cdylib"]
 nalgebra = {version = "0.33", default-features = false, features = ["std"]}
 serde = {version = "1.0.204", default-features = false, features = ["alloc", "derive"], optional = true}
 rayon = {version = "1.10", optional = true}
-smallvec = {version = "1.15.0", default-features = false}
+smallvec = {version = "1.15.0", default-features = false, features = ["union"]}
 
 [dev-dependencies]
 approx = "0.5.1"
@@ -26,7 +26,7 @@ criterion = {version = "0.5", features = ["html_reports"]}
 
 [features]
 # Implements the `Serialize` and `Deserialize` traits from the [`serde`](https://crates.io/crates/serde) crate for the quadrature rule structs.
-serde = ["dep:serde"]
+serde = ["dep:serde", "smallvec/serde"]
 # Enables a parallel version of the `integrate` function on the quadrature rule structs. Can speed up integration if evaluating the integrand is expensive (takes ≫100 µs).
 rayon = ["dep:rayon"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ crate-type = ["lib", "cdylib"]
 nalgebra = {version = "0.33", default-features = false, features = ["std"]}
 serde = {version = "1.0.204", default-features = false, features = ["alloc", "derive"], optional = true}
 rayon = {version = "1.10", optional = true}
+smallvec = {version = "1.15.0", default-features = false}
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/src/chebyshev/mod.rs
+++ b/src/chebyshev/mod.rs
@@ -74,7 +74,8 @@ impl GaussChebyshevFirstKind {
                 .into_par_iter()
                 .rev()
                 .map(|i| ((PI * (2.0 * (i as f64) - 1.0) / (2.0 * n)).cos(), PI / n))
-                .collect::<Vec<_>>().into(),
+                .collect::<Vec<_>>()
+                .into(),
         })
     }
 
@@ -186,7 +187,8 @@ impl GaussChebyshevSecondKind {
                             PI * over_n_plus_1 * sin_val * sin_val,
                         )
                     })
-                    .collect::<Vec<_>>().into(),
+                    .collect::<Vec<_>>()
+                    .into(),
             })
         } else {
             None

--- a/src/chebyshev/mod.rs
+++ b/src/chebyshev/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! This rule can integrate formulas on the form f(x) * (1 - x^2)^`a` on finite intervals, where `a` is either -1/2 or 1/2.
 
-use crate::{Node, Weight, __impl_node_weight_rule};
+use crate::{Node, Weight, __impl_node_weight_rule, data_api::NODE_WEIGHT_RULE_INLINE_SIZE};
 
 use core::f64::consts::PI;
 
@@ -10,6 +10,7 @@ use core::f64::consts::PI;
 use rayon::iter::{
     IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,
 };
+use smallvec::SmallVec;
 
 /// A Gauss-Chebyshev quadrature scheme of the first kind.
 ///
@@ -29,7 +30,7 @@ use rayon::iter::{
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GaussChebyshevFirstKind {
-    node_weight_pairs: Box<[(Node, Weight)]>,
+    node_weight_pairs: SmallVec<[(Node, Weight); NODE_WEIGHT_RULE_INLINE_SIZE]>,
 }
 
 impl GaussChebyshevFirstKind {
@@ -136,7 +137,7 @@ __impl_node_weight_rule! {GaussChebyshevFirstKind, GaussChebyshevFirstKindNodes,
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GaussChebyshevSecondKind {
-    node_weight_pairs: Box<[(Node, Weight)]>,
+    node_weight_pairs: SmallVec<[(Node, Weight); NODE_WEIGHT_RULE_INLINE_SIZE]>,
 }
 
 impl GaussChebyshevSecondKind {

--- a/src/chebyshev/mod.rs
+++ b/src/chebyshev/mod.rs
@@ -74,7 +74,7 @@ impl GaussChebyshevFirstKind {
                 .into_par_iter()
                 .rev()
                 .map(|i| ((PI * (2.0 * (i as f64) - 1.0) / (2.0 * n)).cos(), PI / n))
-                .collect(),
+                .collect::<Vec<_>>().into(),
         })
     }
 
@@ -186,7 +186,7 @@ impl GaussChebyshevSecondKind {
                             PI * over_n_plus_1 * sin_val * sin_val,
                         )
                     })
-                    .collect(),
+                    .collect::<Vec<_>>().into(),
             })
         } else {
             None

--- a/src/data_api.rs
+++ b/src/data_api.rs
@@ -22,7 +22,7 @@ pub type Weight = f64;
 pub const NODE_WEIGHT_RULE_INLINE_SIZE: usize = 4;
 
 /// This macro implements the data access API for the given quadrature rule struct that contains
-/// a field named `node_weight_pairs` of the type `Box<[(Node, Weight)]>`.
+/// a field named `node_weight_pairs` of the type `SmallVec<[(Node, Weight); NODE_WEIGHT_RULE_INLINE_SIZE]>`.
 /// It takes in the name of the quadrature rule struct as well as the names it should give the iterators
 /// over its nodes, weights, and both, as well as the iterator returned by the [`IntoIterator`] trait.
 #[doc(hidden)]

--- a/src/hermite/mod.rs
+++ b/src/hermite/mod.rs
@@ -87,7 +87,7 @@ impl GaussHermite {
         // calculate eigenvalues & vectors
         let eigen = companion_matrix.symmetric_eigen();
 
-        // zip together the iterator over nodes with the one over weights and collect into a Box<[(f64, f64)]>
+        // zip together the iterator over nodes with the one over weights and collect
         let mut node_weight_pairs: SmallVec<[(Node, Weight); NODE_WEIGHT_RULE_INLINE_SIZE]> = eigen
             .eigenvalues
             .iter()

--- a/src/hermite/mod.rs
+++ b/src/hermite/mod.rs
@@ -20,8 +20,11 @@
 
 #[cfg(feature = "rayon")]
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
+use smallvec::SmallVec;
 
-use crate::{DMatrixf64, Node, Weight, __impl_node_weight_rule};
+use crate::{
+    DMatrixf64, Node, Weight, __impl_node_weight_rule, data_api::NODE_WEIGHT_RULE_INLINE_SIZE,
+};
 
 use core::f64::consts::PI;
 
@@ -47,7 +50,7 @@ use core::f64::consts::PI;
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GaussHermite {
-    node_weight_pairs: Box<[(Node, Weight)]>,
+    node_weight_pairs: SmallVec<[(Node, Weight); NODE_WEIGHT_RULE_INLINE_SIZE]>,
 }
 
 impl GaussHermite {
@@ -85,7 +88,7 @@ impl GaussHermite {
         let eigen = companion_matrix.symmetric_eigen();
 
         // zip together the iterator over nodes with the one over weights and collect into a Box<[(f64, f64)]>
-        let mut node_weight_pairs: Box<[(Node, Weight)]> = eigen
+        let mut node_weight_pairs: SmallVec<[(Node, Weight); NODE_WEIGHT_RULE_INLINE_SIZE]> = eigen
             .eigenvalues
             .iter()
             .copied()

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -132,7 +132,7 @@ impl GaussJacobi {
                 / gamma(alpha + beta + 1.0)
                 / (alpha + beta + 1.0);
 
-        // zip together the iterator over nodes with the one over weights and return as Box<[(f64, f64)]>
+        // zip together the iterator over nodes with the one over weights and collect
         let mut node_weight_pairs: SmallVec<[(f64, f64); NODE_WEIGHT_RULE_INLINE_SIZE]> = eigen
             .eigenvalues
             .iter()

--- a/src/jacobi/mod.rs
+++ b/src/jacobi/mod.rs
@@ -21,11 +21,12 @@
 
 #[cfg(feature = "rayon")]
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
+use smallvec::SmallVec;
 
 use crate::gamma::gamma;
 use crate::{
     DMatrixf64, GaussChebyshevFirstKind, GaussChebyshevSecondKind, GaussLegendre, Node, Weight,
-    __impl_node_weight_rule,
+    __impl_node_weight_rule, data_api::NODE_WEIGHT_RULE_INLINE_SIZE,
 };
 
 use std::backtrace::Backtrace;
@@ -53,7 +54,7 @@ use std::backtrace::Backtrace;
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GaussJacobi {
-    node_weight_pairs: Box<[(Node, Weight)]>,
+    node_weight_pairs: SmallVec<[(Node, Weight); NODE_WEIGHT_RULE_INLINE_SIZE]>,
     alpha: f64,
     beta: f64,
 }
@@ -132,7 +133,7 @@ impl GaussJacobi {
                 / (alpha + beta + 1.0);
 
         // zip together the iterator over nodes with the one over weights and return as Box<[(f64, f64)]>
-        let mut node_weight_pairs: Box<[(f64, f64)]> = eigen
+        let mut node_weight_pairs: SmallVec<[(f64, f64); NODE_WEIGHT_RULE_INLINE_SIZE]> = eigen
             .eigenvalues
             .iter()
             .copied()
@@ -276,7 +277,7 @@ impl std::error::Error for GaussJacobiError {}
 impl From<GaussLegendre> for GaussJacobi {
     fn from(value: GaussLegendre) -> Self {
         Self {
-            node_weight_pairs: value.into_node_weight_pairs(),
+            node_weight_pairs: value.into_smallvec_of_node_weight_pairs(),
             alpha: 0.0,
             beta: 0.0,
         }
@@ -287,7 +288,7 @@ impl From<GaussLegendre> for GaussJacobi {
 impl From<GaussChebyshevFirstKind> for GaussJacobi {
     fn from(value: GaussChebyshevFirstKind) -> Self {
         Self {
-            node_weight_pairs: value.into_node_weight_pairs(),
+            node_weight_pairs: value.into_smallvec_of_node_weight_pairs(),
             alpha: -0.5,
             beta: -0.5,
         }
@@ -298,7 +299,7 @@ impl From<GaussChebyshevFirstKind> for GaussJacobi {
 impl From<GaussChebyshevSecondKind> for GaussJacobi {
     fn from(value: GaussChebyshevSecondKind) -> Self {
         Self {
-            node_weight_pairs: value.into_node_weight_pairs(),
+            node_weight_pairs: value.into_smallvec_of_node_weight_pairs(),
             alpha: 0.5,
             beta: 0.5,
         }

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -103,7 +103,7 @@ impl GaussLaguerre {
 
         let scale_factor = gamma(alpha + 1.0);
 
-        // zip together the iterator over nodes with the one over weights and return as Box<[(f64, f64)]>
+        // zip together the iterator over nodes with the one over weights and collect
         let mut node_weight_pairs: SmallVec<[(f64, f64); NODE_WEIGHT_RULE_INLINE_SIZE]> = eigen
             .eigenvalues
             .into_iter()

--- a/src/laguerre/mod.rs
+++ b/src/laguerre/mod.rs
@@ -20,7 +20,9 @@
 
 #[cfg(feature = "rayon")]
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
+use smallvec::SmallVec;
 
+use crate::data_api::NODE_WEIGHT_RULE_INLINE_SIZE;
 use crate::gamma::gamma;
 use crate::{DMatrixf64, Node, Weight, __impl_node_weight_rule};
 
@@ -49,7 +51,7 @@ use std::backtrace::Backtrace;
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GaussLaguerre {
-    node_weight_pairs: Box<[(Node, Weight)]>,
+    node_weight_pairs: SmallVec<[(Node, Weight); NODE_WEIGHT_RULE_INLINE_SIZE]>,
     alpha: f64,
 }
 
@@ -102,7 +104,7 @@ impl GaussLaguerre {
         let scale_factor = gamma(alpha + 1.0);
 
         // zip together the iterator over nodes with the one over weights and return as Box<[(f64, f64)]>
-        let mut node_weight_pairs: Box<[(f64, f64)]> = eigen
+        let mut node_weight_pairs: SmallVec<[(f64, f64); NODE_WEIGHT_RULE_INLINE_SIZE]> = eigen
             .eigenvalues
             .into_iter()
             .copied()

--- a/src/legendre/mod.rs
+++ b/src/legendre/mod.rs
@@ -107,7 +107,8 @@ impl GaussLegendre {
                 .into_par_iter()
                 .rev()
                 .map(|k| NodeWeightPair::new(degree, k).into_tuple())
-                .collect::<Vec<_>>().into(),
+                .collect::<Vec<_>>()
+                .into(),
         })
     }
 

--- a/src/legendre/mod.rs
+++ b/src/legendre/mod.rs
@@ -107,7 +107,7 @@ impl GaussLegendre {
                 .into_par_iter()
                 .rev()
                 .map(|k| NodeWeightPair::new(degree, k).into_tuple())
-                .collect(),
+                .collect::<Vec<_>>().into(),
         })
     }
 

--- a/src/legendre/mod.rs
+++ b/src/legendre/mod.rs
@@ -29,8 +29,9 @@ use rayon::prelude::{
 mod bogaert;
 
 use bogaert::NodeWeightPair;
+use smallvec::SmallVec;
 
-use crate::{Node, Weight, __impl_node_weight_rule};
+use crate::{Node, Weight, __impl_node_weight_rule, data_api::NODE_WEIGHT_RULE_INLINE_SIZE};
 
 /// A Gauss-Legendre quadrature scheme.
 ///
@@ -67,7 +68,7 @@ use crate::{Node, Weight, __impl_node_weight_rule};
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GaussLegendre {
-    node_weight_pairs: Box<[(Node, Weight)]>,
+    node_weight_pairs: SmallVec<[(Node, Weight); NODE_WEIGHT_RULE_INLINE_SIZE]>,
 }
 
 impl GaussLegendre {


### PR DESCRIPTION
This allows the rules to store their data on the stack, speeding up construction of small rules. It also potentially speeds up integration with small rules.