### PR TITLE
Add a CI job that runs the test suite under MIRI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -100,3 +100,13 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           fail_ci_if_error: true
+
+  miri:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@nightly
+      with:
+        components: miri,rust-src
+    - name: Run miri
+      run: cargo +nightly miri test --all-features


### PR DESCRIPTION
This is to check the crate for improper use of unsafe code.