### PR TITLE
Don't package the benchmarks to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 description = "Library for applying Gaussian quadrature to integrate a function"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/domidre/gauss-quad"
-exclude = ["CHANGELOG.md", ".gitignore"]
+exclude = ["CHANGELOG.md", ".gitignore", "benches"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
The publishing process removes the "[[bench]]" sections of the Cargo.toml if they are excluded, so this doesn't break the crate.